### PR TITLE
feat: US-4 auth middleware

### DIFF
--- a/internal/delivery/rest/error_handler.go
+++ b/internal/delivery/rest/error_handler.go
@@ -47,6 +47,12 @@ func usecaseErrorToRESTResponse(c echo.Context, err error) error {
 				ErrorCode:    http.StatusText(http.StatusUnauthorized),
 				ErrorMessage: e.Message,
 			})
+		case usecase.ErrForbidden:
+			return c.JSON(http.StatusForbidden, StandardErrorResponse{
+				StatusCode:   http.StatusForbidden,
+				ErrorCode:    http.StatusText(http.StatusForbidden),
+				ErrorMessage: e.Message,
+			})
 		}
 	}
 }

--- a/internal/delivery/rest/middleware.go
+++ b/internal/delivery/rest/middleware.go
@@ -1,0 +1,61 @@
+package rest
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/luckyAkbar/atec/internal/model"
+	"github.com/luckyAkbar/atec/internal/usecase"
+)
+
+func (s *service) AuthMiddleware(allowAllAuthorized, allowAdminOnly bool) echo.MiddlewareFunc {
+	if !allowAdminOnly && !allowAllAuthorized {
+		panic("invalid configuration for auth middleware. one of the params must be true")
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			token := getAccessToken(c.Request())
+			if token == "" {
+				return c.JSON(http.StatusUnauthorized, StandardErrorResponse{
+					StatusCode:   http.StatusUnauthorized,
+					ErrorMessage: "missing required auth token",
+					ErrorCode:    http.StatusText(http.StatusUnauthorized),
+				})
+			}
+
+			output, err := s.authUsecase.AllowAccess(c.Request().Context(), usecase.AllowAccessInput{
+				Token:              token,
+				AllowAllAuthorized: allowAllAuthorized,
+				AllowAdminOnly:     allowAdminOnly,
+			})
+
+			if err != nil {
+				return usecaseErrorToRESTResponse(c, err)
+			}
+
+			authUser := model.AuthUser{
+				ID:   output.UserID,
+				Role: output.UserRole,
+			}
+
+			ctx := c.Request().Context()
+			newCtx := model.SetUserToCtx(ctx, authUser)
+
+			c.SetRequest(c.Request().WithContext(newCtx))
+
+			return next(c)
+		}
+	}
+}
+
+func getAccessToken(req *http.Request) string {
+	authHeaders := strings.Split(req.Header.Get("Authorization"), " ")
+
+	if len(authHeaders) != 1 {
+		return ""
+	}
+
+	return strings.TrimSpace(authHeaders[0])
+}

--- a/internal/model/auth.go
+++ b/internal/model/auth.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"context"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+type authCtxKey string
+
+var (
+	authUserCtxKey authCtxKey = "github.com/luckyAkbar/atec/internal/model:AuthUser"
+)
+
+// AuthUser represent authenticated user and will be used to embed value to context
+type AuthUser struct {
+	ID   uuid.UUID
+	Role Roles
+}
+
+// SetUserToCtx set user to context
+func SetUserToCtx(ctx context.Context, user AuthUser) context.Context {
+	return context.WithValue(ctx, authUserCtxKey, user)
+}
+
+// GetUserFromCtx get user from context
+func GetUserFromCtx(ctx context.Context) *AuthUser {
+	user, ok := ctx.Value(authUserCtxKey).(AuthUser)
+	if !ok {
+		return nil
+	}
+
+	return &user
+}
+
+// LoginTokenClaims custom claims to be placed in payload for login jwt token
+type LoginTokenClaims struct {
+	Role Roles `json:"role"`
+
+	jwt.RegisteredClaims
+}

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -126,12 +126,15 @@ func (u *AuthUsecase) HandleLogin(ctx context.Context, input LoginInput) (*Login
 		}
 	}
 
-	loginToken, err := u.sharedCryptor.CreateJWT(jwt.RegisteredClaims{
+	loginToken, err := u.sharedCryptor.CreateJWT(model.LoginTokenClaims{
+		Role: user.Roles,
+		RegisteredClaims: jwt.RegisteredClaims{
 		Issuer:    string(TokenIssuerSystem),
 		Subject:   string(LoginToken),
 		Audience:  []string{user.ID.String()},
 		ExpiresAt: jwt.NewNumericDate(time.Now().Add(config.LoginTokenExpiry())),
 		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
 	})
 
 	if err != nil {

--- a/internal/usecase/error.go
+++ b/internal/usecase/error.go
@@ -24,4 +24,6 @@ var (
 	ErrUnauthorized = errors.New("unauthorized")
 
 	ErrNotFound = errors.New("not found")
+
+	ErrForbidden = errors.New("forbidden")
 )


### PR DESCRIPTION
this PR adds new functionality to use authentication middleware to make certain routes accessible only by authenticated user or only by user with roles set to admin.

this PR solves all the subtasks defined in the US-1 story tiket -> [US-4] Sistem Autentikasi

all the subtask solved are listed below:

1. [ST-17] Membuat fungsi untuk memvalidasi token JWT untuk memastikan token masih valid
2. [ST-18] Membuat fungsi sebagai middleware sebagai validator auth header untuk melindungi unauthorized akses terhadap endpoint tertentu pada API