### PR TITLE
feat: us-7 change package activation status

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1350,8 +1350,8 @@ const docTemplate = `{
         "rest.ActivationPackageOutput": {
             "type": "object",
             "properties": {
-                "status": {
-                    "type": "boolean"
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1342,8 +1342,8 @@
         "rest.ActivationPackageOutput": {
             "type": "object",
             "properties": {
-                "status": {
-                    "type": "boolean"
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -46,8 +46,8 @@ definitions:
     type: object
   rest.ActivationPackageOutput:
     properties:
-      status:
-        type: boolean
+      message:
+        type: string
     type: object
   rest.CreatePackageInput:
     properties:

--- a/internal/delivery/rest/input.go
+++ b/internal/delivery/rest/input.go
@@ -82,7 +82,8 @@ type UpdatePackageInput struct {
 
 // ActivationPackageInput input
 type ActivationPackageInput struct {
-	Status bool `json:"status"`
+	Status    bool      `json:"status"`
+	PackageID uuid.UUID `json:"-" param:"package_id"`
 }
 
 // SDTemplateSubGroupDetail input
@@ -99,16 +100,6 @@ type CreateATECTemplateInput struct {
 	PositiveIndiationText  string                     `json:"positive_indication_text" validate:"required"`
 	NegativeIndicationText string                     `json:"negative_indication_text" validate:"required"`
 	SubGroupDetails        []SDTemplateSubGroupDetail `json:"sub_group_details" validate:"min=1,dive"`
-}
-
-// UpdateATECTemplateInput input
-type UpdateATECTemplateInput struct {
-	CreateATECTemplateInput
-}
-
-// ActivateTemplateInput input
-type ActivateTemplateInput struct {
-	Status bool `json:"status"`
 }
 
 // GetATECQuestionnaireInput input

--- a/internal/delivery/rest/output.go
+++ b/internal/delivery/rest/output.go
@@ -77,7 +77,7 @@ type UpdatePackageOutput struct {
 
 // ActivationPackageOutput output
 type ActivationPackageOutput struct {
-	Status bool `json:"status"`
+	Message string
 }
 
 // CreateATECTemplateOutput output
@@ -88,11 +88,6 @@ type CreateATECTemplateOutput struct {
 // UpdateATECTemplateOutput output
 type UpdateATECTemplateOutput struct {
 	ID uuid.UUID `json:"id"`
-}
-
-// ActivateTemplateOutput output
-type ActivateTemplateOutput struct {
-	Status bool `json:"status"`
 }
 
 // GetATECQuestionnaireOutput output

--- a/internal/delivery/rest/package.go
+++ b/internal/delivery/rest/package.go
@@ -261,7 +261,31 @@ func (s *service) HandleUpdatePackage() echo.HandlerFunc {
 // @Router			/v1/atec/packages/{package_id} [patch]
 func (s *service) HandleActivationPackage() echo.HandlerFunc {
 	return func(c echo.Context) error {
-		return c.NoContent(http.StatusNotImplemented)
+		input := &ActivationPackageInput{}
+		if err := c.Bind(input); err != nil {
+			return c.JSON(http.StatusBadRequest, StandardErrorResponse{
+				StatusCode:   http.StatusBadRequest,
+				ErrorMessage: "failed to parse input",
+				ErrorCode:    http.StatusText(http.StatusBadRequest),
+			})
+		}
+
+		output, err := s.packageUsecase.ChangeActiveStatus(c.Request().Context(), usecase.ChangeActiveStatusInput{
+			PackageID:    input.PackageID,
+			ActiveStatus: input.Status,
+		})
+
+		if err != nil {
+			return usecaseErrorToRESTResponse(c, err)
+		}
+
+		return c.JSON(http.StatusOK, StandardSuccessResponse{
+			StatusCode: http.StatusOK,
+			Message:    http.StatusText(http.StatusOK),
+			Data: ActivationPackageOutput{
+				Message: output.Message,
+			},
+		})
 	}
 }
 

--- a/internal/delivery/rest/rest.go
+++ b/internal/delivery/rest/rest.go
@@ -46,7 +46,7 @@ func (s *service) initV1Routes() {
 
 	s.v1.POST("/atec/packages", s.HandleCreatePackage(), s.AuthMiddleware(false, true))
 	s.v1.PUT("/atec/packages/:package_id", s.HandleUpdatePackage())
-	s.v1.PATCH("/atec/packages/:package_id", s.HandleActivationPackage())
+	s.v1.PATCH("/atec/packages/:package_id", s.HandleActivationPackage(), s.AuthMiddleware(false, true))
 	s.v1.DELETE("/atec/packages/:package_id", s.HandleDeletePackage())
 	s.v1.GET("/atec/packages/active", s.HandleSearchActivePackage())
 

--- a/internal/repository/package.go
+++ b/internal/repository/package.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/luckyAkbar/atec/internal/model"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // PackageRepo repository for packages
@@ -16,6 +17,8 @@ type PackageRepo struct {
 // PackageRepoIface interface for PackageRepo
 type PackageRepoIface interface {
 	Create(ctx context.Context, input CreatePackageInput) (*model.Package, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*model.Package, error)
+	Update(ctx context.Context, id uuid.UUID, input UpdatePackageInput) (*model.Package, error)
 }
 
 // NewPackageRepo create new package repo instance
@@ -41,6 +44,52 @@ func (r *PackageRepo) Create(ctx context.Context, input CreatePackageInput) (*mo
 	}
 
 	if err := r.db.WithContext(ctx).Create(pack).Error; err != nil {
+		return nil, err
+	}
+
+	return pack, nil
+}
+
+// FindByID find package by id
+func (r *PackageRepo) FindByID(ctx context.Context, id uuid.UUID) (*model.Package, error) {
+	pack := &model.Package{}
+
+	err := r.db.WithContext(ctx).Take(pack, "id = ?", id).Error
+	switch err {
+	default:
+		return nil, err
+	case gorm.ErrRecordNotFound:
+		return nil, ErrNotFound
+	case nil:
+		return pack, nil
+	}
+}
+
+// UpdatePackageInput input
+type UpdatePackageInput struct {
+	ActiveStatus *bool
+}
+
+// ToUpdateFields convert the update params to gorm dynamic update fields
+func (upi UpdatePackageInput) ToUpdateFields() map[string]interface{} {
+	fields := map[string]interface{}{}
+
+	if upi.ActiveStatus != nil {
+		fields["is_active"] = *upi.ActiveStatus
+	}
+
+	return fields
+}
+
+// Update update package record by its id
+func (r *PackageRepo) Update(ctx context.Context, id uuid.UUID, input UpdatePackageInput) (*model.Package, error) {
+	pack := &model.Package{}
+
+	err := r.db.WithContext(ctx).Model(pack).
+		Clauses(clause.Returning{}).Where("id = ?", id).
+		Updates(input.ToUpdateFields()).Error
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/usecase/package.go
+++ b/internal/usecase/package.go
@@ -19,6 +19,7 @@ type PackageUsecase struct {
 // PackageUsecaseIface interface
 type PackageUsecaseIface interface {
 	Create(ctx context.Context, input CreatePackageInput) (*CreatePackageOutput, error)
+	ChangeActiveStatus(ctx context.Context, input ChangeActiveStatusInput) (*ChangeActiveStatusOutput, error)
 }
 
 // NewPackageUsecase create new PackageUsecase instance
@@ -84,5 +85,82 @@ func (u *PackageUsecase) Create(ctx context.Context, input CreatePackageInput) (
 
 	return &CreatePackageOutput{
 		ID: pack.ID,
+	}, nil
+}
+
+// ChangeActiveStatusInput input
+type ChangeActiveStatusInput struct {
+	PackageID    uuid.UUID `validate:"required"`
+	ActiveStatus bool
+}
+
+// Validate validate ChangeActiveStatusInput
+func (casi ChangeActiveStatusInput) Validate() error {
+	return common.Validator.Struct(casi)
+}
+
+// ChangeActiveStatusOutput output
+type ChangeActiveStatusOutput struct {
+	Message string
+}
+
+// ChangeActiveStatus change package active status from its id. If the package is locked, will raise and forbidden error
+func (u *PackageUsecase) ChangeActiveStatus(ctx context.Context, input ChangeActiveStatusInput) (*ChangeActiveStatusOutput, error) {
+	logger := logrus.WithContext(ctx).WithField("input", helper.Dump(input))
+
+	if err := input.Validate(); err != nil {
+		return nil, UsecaseError{
+			ErrType: ErrBadRequest,
+			Message: err.Error(),
+		}
+	}
+
+	pack, err := u.packageRepo.FindByID(ctx, input.PackageID)
+	switch err {
+	default:
+		logger.WithError(err).Error("failed to fetch package from database")
+
+		return nil, UsecaseError{
+			ErrType: ErrInternal,
+			Message: ErrInternal.Error(),
+		}
+	case repository.ErrNotFound:
+		return nil, UsecaseError{
+			ErrType: ErrNotFound,
+			Message: ErrNotFound.Error(),
+		}
+	case nil:
+		break
+	}
+
+	// early return if no need to change active status
+	if pack.IsActive == input.ActiveStatus {
+		return &ChangeActiveStatusOutput{
+			Message: "ok",
+		}, nil
+	}
+
+	if pack.IsLocked {
+		return nil, UsecaseError{
+			ErrType: ErrForbidden,
+			Message: "package is already locked",
+		}
+	}
+
+	_, err = u.packageRepo.Update(ctx, input.PackageID, repository.UpdatePackageInput{
+		ActiveStatus: &input.ActiveStatus,
+	})
+
+	if err != nil {
+		logger.WithError(err).Error("failed to change package activation status to database")
+
+		return nil, UsecaseError{
+			ErrType: ErrInternal,
+			Message: ErrInternal.Error(),
+		}
+	}
+
+	return &ChangeActiveStatusOutput{
+		Message: "ok",
 	}, nil
 }


### PR DESCRIPTION
This PR will resolve US-7 ticket:  [US-7] Aktifasi / Deaktifasi Paket Kuesioner

The detailed list of subtask included in this PR are as follows:

1. [ST-26] Membuat fungsi untuk memvalidasi secara keseluruhan pada data paket kuesioner ATEC terhadap data templat standar ATEC agar kuesioner yang dibuat tetap konsisten
2. [ST-27] Membuat fungsi pada usecase layer untuk menangani permintaan untuk melakukan perubahan status aktifasi pada paket kuesioner ATEC
3. [ST-28] Membuat fungsi pada presenter layer untuk mengekspos utilitas perubahan status aktifasi paket kuesioner ATEC ke API endpoint