### PR TITLE
feat: us 13 find active questionnaire package

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -110,7 +110,10 @@ const docTemplate = `{
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/rest.SearchActivePackageOutput"
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/rest.SearchActivePackageOutput"
+                                            }
                                         }
                                     }
                                 }
@@ -1551,9 +1554,14 @@ const docTemplate = `{
         "rest.SearchActivePackageOutput": {
             "type": "object",
             "properties": {
-                "packages": {
-                    "type": "array",
-                    "items": {}
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "questionnaire": {
+                    "$ref": "#/definitions/model.Questionnaire"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -102,7 +102,10 @@
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/rest.SearchActivePackageOutput"
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/rest.SearchActivePackageOutput"
+                                            }
                                         }
                                     }
                                 }
@@ -1543,9 +1546,14 @@
         "rest.SearchActivePackageOutput": {
             "type": "object",
             "properties": {
-                "packages": {
-                    "type": "array",
-                    "items": {}
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "questionnaire": {
+                    "$ref": "#/definitions/model.Questionnaire"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -154,9 +154,12 @@ definitions:
     type: object
   rest.SearchActivePackageOutput:
     properties:
-      packages:
-        items: {}
-        type: array
+      id:
+        type: string
+      name:
+        type: string
+      questionnaire:
+        $ref: '#/definitions/model.Questionnaire'
     type: object
   rest.SearchChildernOutput:
     properties:
@@ -476,7 +479,9 @@ paths:
             - $ref: '#/definitions/rest.StandardSuccessResponse'
             - properties:
                 data:
-                  $ref: '#/definitions/rest.SearchActivePackageOutput'
+                  items:
+                    $ref: '#/definitions/rest.SearchActivePackageOutput'
+                  type: array
               type: object
         "400":
           description: Bad request

--- a/internal/delivery/rest/output.go
+++ b/internal/delivery/rest/output.go
@@ -4,11 +4,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/luckyAkbar/atec/internal/model"
 )
 
 // SearchActivePackageOutput output
 type SearchActivePackageOutput struct {
-	Packages []any `json:"packages"`
+	ID            uuid.UUID           `json:"id"`
+	Questionnaire model.Questionnaire `json:"questionnaire"`
+	Name          string              `json:"name"`
 }
 
 // SubmitQuestionnaireOutput output

--- a/internal/delivery/rest/package.go
+++ b/internal/delivery/rest/package.go
@@ -353,12 +353,30 @@ func (s *service) HandleDeletePackage() echo.HandlerFunc {
 // @Tags			ATEC Package
 // @Accept			json
 // @Produce		json
-// @Success		200	{object}	StandardSuccessResponse{data=SearchActivePackageOutput}	"Successful response"
-// @Failure		400	{object}	StandardErrorResponse									"Bad request"
-// @Failure		500	{object}	StandardErrorResponse									"Internal Error"
+// @Success		200	{object}	StandardSuccessResponse{data=[]SearchActivePackageOutput}	"Successful response"
+// @Failure		400	{object}	StandardErrorResponse										"Bad request"
+// @Failure		500	{object}	StandardErrorResponse										"Internal Error"
 // @Router			/v1/atec/packages/active [get]
 func (s *service) HandleSearchActivePackage() echo.HandlerFunc {
 	return func(c echo.Context) error {
-		return c.NoContent(http.StatusNotImplemented)
+		packages, err := s.packageUsecase.FindActiveQuestionnaires(c.Request().Context())
+		if err != nil {
+			return usecaseErrorToRESTResponse(c, err)
+		}
+
+		output := []SearchActivePackageOutput{}
+		for _, pack := range packages {
+			output = append(output, SearchActivePackageOutput{
+				ID:            pack.ID,
+				Questionnaire: pack.Questionnaire,
+				Name:          pack.Name,
+			})
+		}
+
+		return c.JSON(http.StatusOK, StandardSuccessResponse{
+			StatusCode: http.StatusOK,
+			Message:    http.StatusText(http.StatusOK),
+			Data:       output,
+		})
 	}
 }


### PR DESCRIPTION
This PR contains necessary features and component to perform searching for active questionnaire. The way it achieve it is using query to fetch packages rows where the field `is_active `is already set to `true `(activated by Admin level user)

This PR resolve issue stated in this ticket: [[US-13]](https://0ad.atlassian.net/browse/AA-55?atlOrigin=eyJpIjoiODkwZjYxMjdlYzFkNGY2Nzk3Mzk3NDM0NDM4M2I2YWUiLCJwIjoiaiJ9) Memilih Paket Kuesioner

include these subtask tickets:
1. [[ST-43]](https://0ad.atlassian.net/browse/AA-56?atlOrigin=eyJpIjoiMjViNmZlOGI4MjA2NDFkOWIzYmVlOGFhMjlhMzI2YzgiLCJwIjoiaiJ9) Membuat fungsi pada repository layer untuk mengambil data paket kuesioner ATEC dengan status aktif
2. [[ST-44]](https://0ad.atlassian.net/browse/AA-57?atlOrigin=eyJpIjoiYjBkMTYwNzQ0ZmUxNDU2YThlMWU5MjUxMzY2ODU3MDQiLCJwIjoiaiJ9) Membuat fungsi pada usecase layer untuk menangani permintaan pengguna terhadap paket kuesioner ATEC yang aktif
3. [[ST-45]](https://0ad.atlassian.net/browse/AA-58?atlOrigin=eyJpIjoiZmUzYTY0MmRmY2EwNDI3MmFhNGYyNWUzNmVhODM4ZWQiLCJwIjoiaiJ9) Membuat fungsi pada presenter layer untuk mengekspos utilitas pencarian data paket kuesioner ATEC aktif ke API endpoint