### PR TITLE
feat: us-17 get questionnaire history

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -577,11 +577,14 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "maximum": 100,
+                        "minimum": 1,
                         "type": "integer",
                         "name": "limit",
                         "in": "query"
                     },
                     {
+                        "minimum": 0,
                         "type": "integer",
                         "name": "offset",
                         "in": "query"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -569,11 +569,14 @@
                         "required": true
                     },
                     {
+                        "maximum": 100,
+                        "minimum": 1,
                         "type": "integer",
                         "name": "limit",
                         "in": "query"
                     },
                     {
+                        "minimum": 0,
                         "type": "integer",
                         "name": "offset",
                         "in": "query"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -702,9 +702,12 @@ paths:
         required: true
         type: string
       - in: query
+        maximum: 100
+        minimum: 1
         name: limit
         type: integer
       - in: query
+        minimum: 0
         name: offset
         type: integer
       produces:

--- a/internal/delivery/rest/input.go
+++ b/internal/delivery/rest/input.go
@@ -26,8 +26,8 @@ type SearchQUestionnaireResultsInput struct {
 
 // GetMyQUestionnaireResultsInput input
 type GetMyQUestionnaireResultsInput struct {
-	Limit  int `query:"limit"`
-	Offset int `query:"offset"`
+	Limit  int `json:"limit" query:"limit" validate:"min=1,max=100"`
+	Offset int `json:"offset" query:"offset" validate:"min=0"`
 }
 
 // SignupInput input

--- a/internal/delivery/rest/rest.go
+++ b/internal/delivery/rest/rest.go
@@ -72,7 +72,7 @@ func (s *service) initV1Routes() {
 		s.allowUnauthorizedAccess(), s.AuthMiddleware(true, false),
 	)
 	s.v1.GET("/atec/questionnaires/results", s.HandleSearchQUestionnaireResults(), s.AuthMiddleware(false, true))
-	s.v1.GET("/atec/questionnaires/results/my", s.HandleGetMyQUestionnaireResults())
+	s.v1.GET("/atec/questionnaires/results/my", s.HandleGetMyQUestionnaireResults(), s.AuthMiddleware(true, false))
 
 	s.v1.GET("/swagger/*", echoSwagger.WrapHandler)
 }


### PR DESCRIPTION
This PR will allows registered users to get all submitted questionnaire, either made by himself, or made by Admin level user for his registered children.

This PR solve this ticket: [[US-17]](https://0ad.atlassian.net/browse/AA-73?atlOrigin=eyJpIjoiODcyZTljOTdmMjg3NDdjYmE5MzA2OWE5MzA5NmIwYmYiLCJwIjoiaiJ9) Riwayat Kuesioner ATEC

and all these subtask tickets:
1. [[ST-57]](https://0ad.atlassian.net/browse/AA-74?atlOrigin=eyJpIjoiMzg3MTUxMjE5YjVlNDZiMDgxMGRhMzMwZDFiNjFmMzUiLCJwIjoiaiJ9) Membuat fungsi pada repository layer untuk mencari data jawaban dan skor kuesioner ATEC milik pengguna tertentu dari basis data
2. [[ST-58]](https://0ad.atlassian.net/browse/AA-75?atlOrigin=eyJpIjoiYTM3YzYwMzEwMmEwNGJkMGIzNmI4Mzk4ZmM1YTFhZjUiLCJwIjoiaiJ9) Membuat fungsi pada usecase layer untuk menangani permintaan pencarian data kuesioner milik pengguna tertentu
3. [[ST-59] ](https://0ad.atlassian.net/browse/AA-76?atlOrigin=eyJpIjoiMGZkMjM0ZTU5MjU0NDQ0OGFiNGZmNWM5NTE4ZDliNGUiLCJwIjoiaiJ9) Membuat fungsi pada presenter layer untuk mengekspos utilitas pencarian data kuesioner milik pengguna tertentu ke API endpoint