### PR TITLE
Feat/add support for custom indication ranges

### DIFF
--- a/db/migration/1-init.sql
+++ b/db/migration/1-init.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS packages (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     created_by UUID NOT NULL,
     questionnaire JSONB NOT NULL,
+    indication_categories JSONB NOT NULL,
     name TEXT NOT NULL,
     is_active BOOLEAN DEFAULT FALSE,
     is_locked BOOLEAN DEFAULT FALSE,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1396,6 +1396,30 @@ const docTemplate = `{
                 }
             }
         },
+        "model.IndicationCategory": {
+            "type": "object",
+            "required": [
+                "detail",
+                "maximum_score",
+                "name"
+            ],
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "maximum_score": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "minimum_score": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "model.Questionnaire": {
             "type": "object",
             "additionalProperties": {
@@ -1438,10 +1462,17 @@ const docTemplate = `{
         "rest.CreatePackageInput": {
             "type": "object",
             "required": [
+                "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "indication_categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.IndicationCategory"
+                    }
+                },
                 "package_name": {
                     "type": "string"
                 },
@@ -1784,10 +1815,17 @@ const docTemplate = `{
         "rest.UpdatePackageInput": {
             "type": "object",
             "required": [
+                "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "indication_categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.IndicationCategory"
+                    }
+                },
                 "package_name": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1388,6 +1388,30 @@
                 }
             }
         },
+        "model.IndicationCategory": {
+            "type": "object",
+            "required": [
+                "detail",
+                "maximum_score",
+                "name"
+            ],
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "maximum_score": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "minimum_score": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "model.Questionnaire": {
             "type": "object",
             "additionalProperties": {
@@ -1430,10 +1454,17 @@
         "rest.CreatePackageInput": {
             "type": "object",
             "required": [
+                "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "indication_categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.IndicationCategory"
+                    }
+                },
                 "package_name": {
                     "type": "string"
                 },
@@ -1776,10 +1807,17 @@
         "rest.UpdatePackageInput": {
             "type": "object",
             "required": [
+                "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "indication_categories": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.IndicationCategory"
+                    }
+                },
                 "package_name": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -41,6 +41,23 @@ definitions:
     - options
     - questions
     type: object
+  model.IndicationCategory:
+    properties:
+      detail:
+        type: string
+      maximum_score:
+        minimum: 1
+        type: integer
+      minimum_score:
+        minimum: 0
+        type: integer
+      name:
+        type: string
+    required:
+    - detail
+    - maximum_score
+    - name
+    type: object
   model.Questionnaire:
     additionalProperties:
       $ref: '#/definitions/model.ChecklistGroup'
@@ -68,11 +85,16 @@ definitions:
     type: object
   rest.CreatePackageInput:
     properties:
+      indication_categories:
+        items:
+          $ref: '#/definitions/model.IndicationCategory'
+        type: array
       package_name:
         type: string
       questionnaire:
         $ref: '#/definitions/model.Questionnaire'
     required:
+    - indication_categories
     - package_name
     - questionnaire
     type: object
@@ -300,11 +322,16 @@ definitions:
     type: object
   rest.UpdatePackageInput:
     properties:
+      indication_categories:
+        items:
+          $ref: '#/definitions/model.IndicationCategory'
+        type: array
       package_name:
         type: string
       questionnaire:
         $ref: '#/definitions/model.Questionnaire'
     required:
+    - indication_categories
     - package_name
     - questionnaire
     type: object

--- a/internal/delivery/rest/input.go
+++ b/internal/delivery/rest/input.go
@@ -76,8 +76,9 @@ type UpdateChildernInput struct {
 
 // CreatePackageInput input
 type CreatePackageInput struct {
-	PackageName  string              `json:"package_name" validate:"required"`
-	Quesionnaire model.Questionnaire `json:"questionnaire" validate:"required"`
+	PackageName          string                     `json:"package_name" validate:"required"`
+	Quesionnaire         model.Questionnaire        `json:"questionnaire" validate:"required"`
+	IndicationCategories model.IndicationCategories `json:"indication_categories" validate:"required"`
 }
 
 // UpdatePackageInput input

--- a/internal/delivery/rest/package.go
+++ b/internal/delivery/rest/package.go
@@ -209,8 +209,9 @@ func (s *service) HandleCreatePackage() echo.HandlerFunc {
 		}
 
 		output, err := s.packageUsecase.Create(c.Request().Context(), usecase.CreatePackageInput{
-			PackageName:   input.PackageName,
-			Questionnaire: input.Quesionnaire,
+			PackageName:          input.PackageName,
+			Questionnaire:        input.Quesionnaire,
+			IndicationCategories: input.IndicationCategories,
 		})
 
 		if err != nil {

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -15,15 +15,16 @@ import (
 
 // Package represent packages table on database
 type Package struct {
-	ID            uuid.UUID `gorm:"default:uuid_generate_v4()"`
-	CreatedBy     uuid.UUID
-	Questionnaire Questionnaire
-	Name          string
-	IsActive      bool
-	IsLocked      bool
-	CreatedAt     time.Time `gorm:"default:now()"`
-	UpdatedAt     time.Time
-	DeletedAt     gorm.DeletedAt
+	ID                   uuid.UUID `gorm:"default:uuid_generate_v4()"`
+	CreatedBy            uuid.UUID
+	Questionnaire        Questionnaire
+	IndicationCategories IndicationCategories
+	Name                 string
+	IsActive             bool
+	IsLocked             bool
+	CreatedAt            time.Time `gorm:"default:now()"`
+	UpdatedAt            time.Time `gorm:"default:now()"`
+	DeletedAt            gorm.DeletedAt
 }
 
 // AnswerOption each singular answer option for a given question along with its detail
@@ -135,6 +136,113 @@ func (q *Questionnaire) Scan(_ context.Context, _ *schema.Field, _ reflect.Value
 
 	if err := json.Unmarshal(bytes, q); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// IndicationCategories is the template to decide what indication for a given score.
+type IndicationCategories []IndicationCategory
+
+// GetIndicationCategoryByScore will return the indication category based on score.
+func (ic IndicationCategories) GetIndicationCategoryByScore(score int) IndicationCategory {
+	for _, category := range ic {
+		if category.IsInTheRange(score) {
+			return category
+		}
+	}
+
+	// this is a fallback mechanism. if the score is not found, return an invalid category.
+	// eventhough this should never happen, it is better to have a fallback mechanism instead of returning
+	// dangerous nil value
+	return IndicationCategory{
+		MinimumScore: 0,
+		MaximumScore: 0,
+		Name:         "invalid value",
+		Detail:       "invalid indication",
+	}
+}
+
+// Validate will validate given IndicationCategories to cover entire possible range
+// of ATEC score. Also, to ensure that no overlapping / missing gap on each categories.
+func (ic IndicationCategories) Validate() error {
+	minScore := DefaultATECTemplate.MinimumPossibleScore
+	maxScore := DefaultATECTemplate.MaximumPossibleScore
+
+	for score := minScore; score <= maxScore; score++ {
+		matchCount := 0
+
+		for _, category := range ic {
+			if category.IsInTheRange(score) {
+				matchCount++
+			}
+
+			if err := category.Validate(); err != nil {
+				return err
+			}
+		}
+
+		if matchCount != 1 {
+			return fmt.Errorf("score: %d has no matching categories or overlapping on the defined categories", score)
+		}
+	}
+
+	return nil
+}
+
+// Value implements Valuer/Scanner interface
+func (ic IndicationCategories) Value(_ context.Context, _ *schema.Field, _ reflect.Value, fieldValue interface{}) (interface{}, error) {
+	return json.Marshal(fieldValue)
+}
+
+// Scan implements Valuer/Scanner interface
+func (ic *IndicationCategories) Scan(_ context.Context, _ *schema.Field, _ reflect.Value, dbValue interface{}) error {
+	if dbValue == nil {
+		return nil
+	}
+
+	var bytes []byte
+	switch v := dbValue.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return fmt.Errorf("failed to unmarshal JSONB value: %#v", dbValue)
+	}
+
+	if err := json.Unmarshal(bytes, ic); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IndicationCategory is the detailed structure composing a category to decide indication based on a given score
+type IndicationCategory struct {
+	MinimumScore int    `json:"minimum_score" validate:"min=0"`
+	MaximumScore int    `json:"maximum_score" validate:"required,min=1"`
+	Name         string `json:"name" validate:"required"`
+	Detail       string `json:"detail" validate:"required"`
+}
+
+// IsInTheRange will check if the given score is in the range of this category
+func (ic IndicationCategory) IsInTheRange(score int) bool {
+	return score >= ic.MinimumScore && score <= ic.MaximumScore
+}
+
+// Validate will validate the given IndicationCategory
+func (ic IndicationCategory) Validate() error {
+	if err := common.Validator.Struct(ic); err != nil {
+		return err
+	}
+
+	if ic.MinimumScore < DefaultATECTemplate.MinimumPossibleScore {
+		return fmt.Errorf("minimum score %d is less than minimum possible score %d", ic.MinimumScore, DefaultATECTemplate.MinimumPossibleScore)
+	}
+
+	if ic.MaximumScore > DefaultATECTemplate.MaximumPossibleScore {
+		return fmt.Errorf("maximum score %d is greater than maximum possible score %d", ic.MaximumScore, DefaultATECTemplate.MaximumPossibleScore)
 	}
 
 	return nil

--- a/internal/model/template.go
+++ b/internal/model/template.go
@@ -2,7 +2,9 @@ package model
 
 // Template is the ATEC template in which contains several known subtest's group
 type Template struct {
-	SubTest SubTest
+	SubTest              SubTest
+	MinimumPossibleScore int
+	MaximumPossibleScore int
 }
 
 // SubtestDetail each questionnaire groups along with its detail
@@ -46,4 +48,9 @@ var DefaultATECTemplate = Template{
 			QuestionCount: 25,
 		},
 	},
+
+	// by design these are the lowest and highest possible score
+	// can be achieved for any given standard atec questionnaire
+	MinimumPossibleScore: 0,
+	MaximumPossibleScore: 179,
 }

--- a/internal/repository/package.go
+++ b/internal/repository/package.go
@@ -32,17 +32,19 @@ func NewPackageRepo(db *gorm.DB) *PackageRepo {
 
 // CreatePackageInput input
 type CreatePackageInput struct {
-	UserID        uuid.UUID
-	PackageName   string
-	Questionnaire model.Questionnaire
+	UserID               uuid.UUID
+	PackageName          string
+	Questionnaire        model.Questionnaire
+	IndicationCategories model.IndicationCategories
 }
 
 // Create insert new record of packages to the database
 func (r *PackageRepo) Create(ctx context.Context, input CreatePackageInput) (*model.Package, error) {
 	pack := &model.Package{
-		CreatedBy:     input.UserID,
-		Questionnaire: input.Questionnaire,
-		Name:          input.PackageName,
+		CreatedBy:            input.UserID,
+		Questionnaire:        input.Questionnaire,
+		Name:                 input.PackageName,
+		IndicationCategories: input.IndicationCategories,
 	}
 
 	if err := r.db.WithContext(ctx).Create(pack).Error; err != nil {

--- a/internal/usecase/package.go
+++ b/internal/usecase/package.go
@@ -34,8 +34,9 @@ func NewPackageUsecase(packageRepo *repository.PackageRepo) *PackageUsecase {
 
 // CreatePackageInput input by embedding direcly model.Questionnaire to simplify the input anotation
 type CreatePackageInput struct {
-	PackageName   string              `validate:"required"`
-	Questionnaire model.Questionnaire `validate:"required"`
+	PackageName          string                     `validate:"required"`
+	Questionnaire        model.Questionnaire        `validate:"required"`
+	IndicationCategories model.IndicationCategories `validate:"required,min=3"`
 }
 
 // Validate validate CreatePackageInput
@@ -44,7 +45,11 @@ func (cpi CreatePackageInput) Validate() error {
 		return err
 	}
 
-	return cpi.Questionnaire.Validate()
+	if err := cpi.Questionnaire.Validate(); err != nil {
+		return err
+	}
+
+	return cpi.IndicationCategories.Validate()
 }
 
 // CreatePackageOutput output
@@ -72,9 +77,10 @@ func (u *PackageUsecase) Create(ctx context.Context, input CreatePackageInput) (
 	}
 
 	pack, err := u.packageRepo.Create(ctx, repository.CreatePackageInput{
-		UserID:        user.ID,
-		PackageName:   input.PackageName,
-		Questionnaire: input.Questionnaire,
+		UserID:               user.ID,
+		PackageName:          input.PackageName,
+		Questionnaire:        input.Questionnaire,
+		IndicationCategories: input.IndicationCategories,
 	})
 
 	if err != nil {

--- a/internal/usecase/questionnaire.go
+++ b/internal/usecase/questionnaire.go
@@ -697,22 +697,24 @@ func wordWrapper(s string) []string {
 
 	result := []string{}
 	ss := strings.Fields(s)
-	appended := false
 
 	var temp string
 
 	for i, word := range ss {
+		appended := false
 		temp += word + " "
+
 		if len(temp) >= optimumTextLength {
 			result = append(result, temp)
 			temp = ""
+
 			appended = true
 		}
 
+		// when it's already the last word and the temp is not empty
+		// just append it to the result
 		if i == len(ss)-1 && !appended {
 			result = append(result, temp)
-
-			break
 		}
 	}
 


### PR DESCRIPTION
This PR will allow Admin level user to customize indication given to each package's questionnaire results. This design choosen because the ATEC mechanism itself doesn't have strict categorization for each score from ATEC questionnaire.

This PR doesn't directly trying to solve a particular user story ticket, rather and improvement. Thus, this PR heavily relates to this ticket: [[US-5]](https://0ad.atlassian.net/browse/AA-23?atlOrigin=eyJpIjoiY2VkYmEwYWUzNWY1NDhiYjgxYWQ5ZGNkMWZmOTQ0N2IiLCJwIjoiaiJ9) Pembuatan Paket Kuesioner