### PR TITLE
Feat/add support to customize image result attribute

### DIFF
--- a/db/migration/1-init.sql
+++ b/db/migration/1-init.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS packages (
     created_by UUID NOT NULL,
     questionnaire JSONB NOT NULL,
     indication_categories JSONB NOT NULL,
+    image_result_attribute_key JSONB NOT NULL,
     name TEXT NOT NULL,
     is_active BOOLEAN DEFAULT FALSE,
     is_locked BOOLEAN DEFAULT FALSE,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1396,6 +1396,33 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ImageResultAttributeKey": {
+            "type": "object",
+            "required": [
+                "indication",
+                "result_id",
+                "submitted_at",
+                "title",
+                "total"
+            ],
+            "properties": {
+                "indication": {
+                    "type": "string"
+                },
+                "result_id": {
+                    "type": "string"
+                },
+                "submitted_at": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "string"
+                }
+            }
+        },
         "model.IndicationCategory": {
             "type": "object",
             "required": [
@@ -1462,11 +1489,15 @@ const docTemplate = `{
         "rest.CreatePackageInput": {
             "type": "object",
             "required": [
+                "image_result_attribute_key",
                 "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "image_result_attribute_key": {
+                    "$ref": "#/definitions/model.ImageResultAttributeKey"
+                },
                 "indication_categories": {
                     "type": "array",
                     "items": {
@@ -1815,11 +1846,15 @@ const docTemplate = `{
         "rest.UpdatePackageInput": {
             "type": "object",
             "required": [
+                "image_result_attribute_key",
                 "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "image_result_attribute_key": {
+                    "$ref": "#/definitions/model.ImageResultAttributeKey"
+                },
                 "indication_categories": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1388,6 +1388,33 @@
                 }
             }
         },
+        "model.ImageResultAttributeKey": {
+            "type": "object",
+            "required": [
+                "indication",
+                "result_id",
+                "submitted_at",
+                "title",
+                "total"
+            ],
+            "properties": {
+                "indication": {
+                    "type": "string"
+                },
+                "result_id": {
+                    "type": "string"
+                },
+                "submitted_at": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "string"
+                }
+            }
+        },
         "model.IndicationCategory": {
             "type": "object",
             "required": [
@@ -1454,11 +1481,15 @@
         "rest.CreatePackageInput": {
             "type": "object",
             "required": [
+                "image_result_attribute_key",
                 "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "image_result_attribute_key": {
+                    "$ref": "#/definitions/model.ImageResultAttributeKey"
+                },
                 "indication_categories": {
                     "type": "array",
                     "items": {
@@ -1807,11 +1838,15 @@
         "rest.UpdatePackageInput": {
             "type": "object",
             "required": [
+                "image_result_attribute_key",
                 "indication_categories",
                 "package_name",
                 "questionnaire"
             ],
             "properties": {
+                "image_result_attribute_key": {
+                    "$ref": "#/definitions/model.ImageResultAttributeKey"
+                },
                 "indication_categories": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -41,6 +41,25 @@ definitions:
     - options
     - questions
     type: object
+  model.ImageResultAttributeKey:
+    properties:
+      indication:
+        type: string
+      result_id:
+        type: string
+      submitted_at:
+        type: string
+      title:
+        type: string
+      total:
+        type: string
+    required:
+    - indication
+    - result_id
+    - submitted_at
+    - title
+    - total
+    type: object
   model.IndicationCategory:
     properties:
       detail:
@@ -85,6 +104,8 @@ definitions:
     type: object
   rest.CreatePackageInput:
     properties:
+      image_result_attribute_key:
+        $ref: '#/definitions/model.ImageResultAttributeKey'
       indication_categories:
         items:
           $ref: '#/definitions/model.IndicationCategory'
@@ -94,6 +115,7 @@ definitions:
       questionnaire:
         $ref: '#/definitions/model.Questionnaire'
     required:
+    - image_result_attribute_key
     - indication_categories
     - package_name
     - questionnaire
@@ -322,6 +344,8 @@ definitions:
     type: object
   rest.UpdatePackageInput:
     properties:
+      image_result_attribute_key:
+        $ref: '#/definitions/model.ImageResultAttributeKey'
       indication_categories:
         items:
           $ref: '#/definitions/model.IndicationCategory'
@@ -331,6 +355,7 @@ definitions:
       questionnaire:
         $ref: '#/definitions/model.Questionnaire'
     required:
+    - image_result_attribute_key
     - indication_categories
     - package_name
     - questionnaire

--- a/internal/delivery/rest/input.go
+++ b/internal/delivery/rest/input.go
@@ -76,9 +76,10 @@ type UpdateChildernInput struct {
 
 // CreatePackageInput input
 type CreatePackageInput struct {
-	PackageName          string                     `json:"package_name" validate:"required"`
-	Quesionnaire         model.Questionnaire        `json:"questionnaire" validate:"required"`
-	IndicationCategories model.IndicationCategories `json:"indication_categories" validate:"required"`
+	PackageName             string                        `json:"package_name" validate:"required"`
+	Quesionnaire            model.Questionnaire           `json:"questionnaire" validate:"required"`
+	IndicationCategories    model.IndicationCategories    `json:"indication_categories" validate:"required"`
+	ImageResultAttributeKey model.ImageResultAttributeKey `json:"image_result_attribute_key" validate:"required"`
 }
 
 // UpdatePackageInput input

--- a/internal/delivery/rest/package.go
+++ b/internal/delivery/rest/package.go
@@ -23,180 +23,207 @@ import (
 // @Example
 //
 //	{
-//			  "package_name": "string",
-//			  "questionnaire": {
-//			    "0": {
-//			      "custom_name": "Kemampuan Bicara/Berbahasa",
-//			      "options": [
-//			        {
-//			          "description": "Tidak Benar",
-//			          "id": 2,
-//			          "score": 2
-//			        },
-//			        {
-//			          "description": "Agak Benar",
-//			          "id": 1,
-//			          "score": 1
-//			        },
-//			        {
-//			          "description": "Sangat Benar",
-//			          "id": 0,
-//			          "score": 0
-//			        }
-//			      ],
-//			      "questions": [
-//			        "Mengetahui namanya sendiri",
-//			        "Berespon pada \"Tidak\" atau \"Stop\"",
-//			        "Dapat mengikuti perintah",
-//			        "Dapat menggunakan 1 kata (Tidak!, Makan, Air, dll)",
-//			        "Dapat menggunakan 2 kata sekaligus bersamaan (Tidak mau!, Pergi pulang, dll)",
-//			        "Dapat menggunakan 3 kata sekaligus bersamaan (Mau minum susu, dll)",
-//			        "Mengetahui 10 kata atau lebih",
-//			        "Dapat membuat kalimat yang berisi 4 kata atau lebih",
-//			        "Mampu menjelaskan apa yang dia inginkan",
-//			        "Mampu menanyakan pertanyaan yang bermakna",
-//			        "Isi pembicaraan cenderung relevan/bermakna",
-//			        "Sering menggunakan kalimat-kalimat yang berurutan",
-//			        "Bisa mengikuti pembicaraan dengan cukup baik",
-//			        "Memiliki kemampuan bicara/berbahasa yang sesuai dengan seusianya"
-//			      ]
-//			    },
-//			    "1": {
-//			      "custom_name": "Kemampuan Bersosialisasi",
-//			      "options": [
-//			        {
-//			          "description": "Tidak Cocok",
-//			          "id": 0,
-//			          "score": 0
-//			        },
-//			        {
-//			          "description": "Agak Cocok",
-//			          "id": 1,
-//			          "score": 1
-//			        },
-//			        {
-//			          "description": "Sangat Cocok",
-//			          "id": 2,
-//			          "score": 2
-//			        }
-//			      ],
-//			      "questions": [
-//			        "Terlihat seperti berada dalam ‘tempurung’ – Anda tidak bisa menjangkau dia",
-//			        "Mengabaikan orang lain",
-//			        "Ketika dipanggil, hanya sedikit atau malah tidak memperhatikan",
-//			        "Tidak kooperatif dan menolak",
-//			        "Tidak ada kontak mata",
-//			        "Lebih suka menyendiri",
-//			        "Tidak menunjukkan rasa kasih sayang",
-//			        "Tidak mampu menyapa orang tua",
-//			        "Menghindari kontak dengan orang lain",
-//			        "Tidak mampu menirukan orang lain",
-//			        "Tidak suka dipegang atau dipeluk",
-//			        "Tidak mau berbagi atau menunjukkan",
-//			        "Tidak bisa melambaikan tangan \"Da..Dahh\"",
-//			        "Sering tidak setuju / menolak (not compliant)",
-//			        "Tantrum, marah-marah",
-//			        "Tidak mempunyai teman",
-//			        "Jarang tersenyum",
-//			        "Tidak peka terhadap perasaan orang lain",
-//			        "Acuh tak acuh ketika disukai orang lain",
-//			        "Acuh tak acuh ketika ditinggal pergi oleh orang tuanya"
-//			      ]
-//			    },
-//			    "2": {
-//			      "custom_name": "Kesadaran Sensori/Kognitif",
-//			      "options": [
-//			        {
-//			          "description": "Sangat Cocok",
-//			          "id": 0,
-//			          "score": 0
-//			        },
-//			        {
-//			          "description": "Agak Cocok",
-//			          "id": 1,
-//			          "score": 1
-//			        },
-//			        {
-//			          "description": "Tidak Cocok",
-//			          "id": 2,
-//			          "score": 2
-//			        }
-//			      ],
-//			      "questions": [
-//			        "Merespon saat dipanggil namanya",
-//			        "Merespon saat dipuji",
-//			        "Melihat pada orang dan binatang",
-//			        "Melihat pada gambar (dan TV)",
-//			        "Menggambar, mewarnai dan melakukan kesenian",
-//			        "Bermain dengan mainannya secara sesuai",
-//			        "Menggunakan ekspresi wajah yang sesuai",
-//			        "Memahami cerita yang ditayangkan di TV",
-//			        "Memahami penjelasan",
-//			        "Sadar akan lingkungannya",
-//			        "Sadar akan bahaya",
-//			        "Mampu berimajinasi",
-//			        "Memulai aktivitas",
-//			        "Mampu berpakaian sendiri",
-//			        "Memiliki rasa penasaran dan ketertarikan",
-//			        "Suka tantangan, senang mengeksplorasi",
-//			        "Tampak selaras, tidak tampak ‘kosong’",
-//			        "Mampu mengikuti pandangan ke arah semua orang memandang."
-//			      ]
-//			    },
-//			    "3": {
-//			      "custom_name": "Kesehatan Umum, Fisik dan Perilaku",
-//			      "options": [
-//			        {
-//			          "description": "Sangat Bermasalah",
-//			          "id": 3,
-//			          "score": 3
-//			        },
-//			        {
-//			          "description": "Cukup Bermasalah",
-//			          "id": 2,
-//			          "score": 2
-//			        },
-//			        {
-//			          "description": "Sedikit Bermasalah",
-//			          "id": 1,
-//			          "score": 1
-//			        },
-//			        {
-//			          "description": "Tidak bermasalah",
-//			          "id": 0,
-//			          "score": 0
-//			        }
-//			      ],
-//			      "questions": [
-//			        "Mengompol saat tidur",
-//			        "Mengompol di celana/popok",
-//			        "Buang air besar di celana/popok",
-//			        "Diare",
-//			        "Konstipasi / Sembelit",
-//			        "Gangguan Tidur",
-//			        "Makan terlalu banyak / terlalu sedikit",
-//			        "Pilihan makanan yang diinginkan sangat terbatas (extremely limited diet, picky eater)",
-//			        "Hiperaktif",
-//			        "Letargi, lemah, lesu",
-//			        "Memukul atau melukai diri sendiri",
-//			        "Memukul atau melukai orang lain",
-//			        "Destruktif",
-//			        "Sensitif terhadap suara",
-//			        "Cemas / penuh ketakutan",
-//			        "Tidak senang/ mudah rewel/ menangis",
-//			        "Kejang",
-//			        "Bicara secara obsesif",
-//			        "Kaku terhadap rutinitas",
-//			        "Berteriak / menjerit-jerit",
-//			        "Menuntut hal atau cara yang sama berulang-ulang",
-//			        "Sering gelisah / agitasi",
-//			        "Tidak peka terhadap nyeri",
-//			        "Terfokus atau sulit dialihkan dari objek atau topik tertentu",
-//			        "Gerakan repetitive (stimming, menggoyang-goyangkan bagian badan)"
-//			      ]
-//			    }
-//			  }
-//			}
+//	  "package_name": "string",
+//	  "image_result_attribute_key": {
+//	    "indication": "Indikasi",
+//	    "result_id": "ID Hasil",
+//	    "submitted_at": "Dikerjakan Pada",
+//	    "title": "Skor ATEC",
+//	    "total": "Total Skor"
+//	  },
+//	  "indication_categories": [
+//	    {
+//	      "detail": "Menunjukkan kemungkinan bahwa anak memiliki pola perilaku dan keterampuilan komunikasi yang agak normal dan memiliki peluang tinggi untuk menjalani kehidupan normal dan independen yang menunjukkan gejala ASD minimal.",
+//	      "maximum_score": 30,
+//	      "minimum_score": 0,
+//	      "name": "gejala ringan"
+//	    },
+//	    {
+//	      "detail": "Menunjukkan kemungkinan bahwa anak kemungkinan besar akan dapat menjalani kehidupan semi independen tanpa perlu ditempatkan di fasilitas perawatan formal",
+//	      "maximum_score": 50,
+//	      "minimum_score": 31,
+//	      "name": "gejala sedang"
+//	    },
+//	    {
+//	      "detail": "Menunjukkan kemungkinan bahwa anak jatuh ke persentil ke-90 (sangat autis). Anak mungkin akan membutuhkan perawatan berkelanjutan (mungkin di sebuah institusi), dan mungkin tidak dapat mencapai tingkat kebebasan apapun dari orang lain",
+//	      "maximum_score": 179,
+//	      "minimum_score": 51,
+//	      "name": "gejala berat"
+//	    }
+//	  ],
+//	  "questionnaire": {
+//	    "0": {
+//	      "custom_name": "Kemampuan Bicara/Berbahasa",
+//	      "options": [
+//	        {
+//	          "description": "Tidak Benar",
+//	          "id": 2,
+//	          "score": 2
+//	        },
+//	        {
+//	          "description": "Agak Benar",
+//	          "id": 1,
+//	          "score": 1
+//	        },
+//	        {
+//	          "description": "Sangat Benar",
+//	          "id": 0,
+//	          "score": 0
+//	        }
+//	      ],
+//	      "questions": [
+//	        "Mengetahui namanya sendiri",
+//	        "Berespon pada \"Tidak\" atau \"Stop\"",
+//	        "Dapat mengikuti perintah",
+//	        "Dapat menggunakan 1 kata (Tidak!, Makan, Air, dll)",
+//	        "Dapat menggunakan 2 kata sekaligus bersamaan (Tidak mau!, Pergi pulang, dll)",
+//	        "Dapat menggunakan 3 kata sekaligus bersamaan (Mau minum susu, dll)",
+//	        "Mengetahui 10 kata atau lebih",
+//	        "Dapat membuat kalimat yang berisi 4 kata atau lebih",
+//	        "Mampu menjelaskan apa yang dia inginkan",
+//	        "Mampu menanyakan pertanyaan yang bermakna",
+//	        "Isi pembicaraan cenderung relevan/bermakna",
+//	        "Sering menggunakan kalimat-kalimat yang berurutan",
+//	        "Bisa mengikuti pembicaraan dengan cukup baik",
+//	        "Memiliki kemampuan bicara/berbahasa yang sesuai dengan seusianya"
+//	      ]
+//	    },
+//	    "1": {
+//	      "custom_name": "Kemampuan Bersosialisasi",
+//	      "options": [
+//	        {
+//	          "description": "Tidak Cocok",
+//	          "id": 0,
+//	          "score": 0
+//	        },
+//	        {
+//	          "description": "Agak Cocok",
+//	          "id": 1,
+//	          "score": 1
+//	        },
+//	        {
+//	          "description": "Sangat Cocok",
+//	          "id": 2,
+//	          "score": 2
+//	        }
+//	      ],
+//	      "questions": [
+//	        "Terlihat seperti berada dalam ‘tempurung’ – Anda tidak bisa menjangkau dia",
+//	        "Mengabaikan orang lain",
+//	        "Ketika dipanggil, hanya sedikit atau malah tidak memperhatikan",
+//	        "Tidak kooperatif dan menolak",
+//	        "Tidak ada kontak mata",
+//	        "Lebih suka menyendiri",
+//	        "Tidak menunjukkan rasa kasih sayang",
+//	        "Tidak mampu menyapa orang tua",
+//	        "Menghindari kontak dengan orang lain",
+//	        "Tidak mampu menirukan orang lain",
+//	        "Tidak suka dipegang atau dipeluk",
+//	        "Tidak mau berbagi atau menunjukkan",
+//	        "Tidak bisa melambaikan tangan \"Da..Dahh\"",
+//	        "Sering tidak setuju / menolak (not compliant)",
+//	        "Tantrum, marah-marah",
+//	        "Tidak mempunyai teman",
+//	        "Jarang tersenyum",
+//	        "Tidak peka terhadap perasaan orang lain",
+//	        "Acuh tak acuh ketika disukai orang lain",
+//	        "Acuh tak acuh ketika ditinggal pergi oleh orang tuanya"
+//	      ]
+//	    },
+//	    "2": {
+//	      "custom_name": "Kesadaran Sensori/Kognitif",
+//	      "options": [
+//	        {
+//	          "description": "Sangat Cocok",
+//	          "id": 0,
+//	          "score": 0
+//	        },
+//	        {
+//	          "description": "Agak Cocok",
+//	          "id": 1,
+//	          "score": 1
+//	        },
+//	        {
+//	          "description": "Tidak Cocok",
+//	          "id": 2,
+//	          "score": 2
+//	        }
+//	      ],
+//	      "questions": [
+//	        "Merespon saat dipanggil namanya",
+//	        "Merespon saat dipuji",
+//	        "Melihat pada orang dan binatang",
+//	        "Melihat pada gambar (dan TV)",
+//	        "Menggambar, mewarnai dan melakukan kesenian",
+//	        "Bermain dengan mainannya secara sesuai",
+//	        "Menggunakan ekspresi wajah yang sesuai",
+//	        "Memahami cerita yang ditayangkan di TV",
+//	        "Memahami penjelasan",
+//	        "Sadar akan lingkungannya",
+//	        "Sadar akan bahaya",
+//	        "Mampu berimajinasi",
+//	        "Memulai aktivitas",
+//	        "Mampu berpakaian sendiri",
+//	        "Memiliki rasa penasaran dan ketertarikan",
+//	        "Suka tantangan, senang mengeksplorasi",
+//	        "Tampak selaras, tidak tampak ‘kosong’",
+//	        "Mampu mengikuti pandangan ke arah semua orang memandang."
+//	      ]
+//	    },
+//	    "3": {
+//	      "custom_name": "Kesehatan Umum, Fisik dan Perilaku",
+//	      "options": [
+//	        {
+//	          "description": "Sangat Bermasalah",
+//	          "id": 3,
+//	          "score": 3
+//	        },
+//	        {
+//	          "description": "Cukup Bermasalah",
+//	          "id": 2,
+//	          "score": 2
+//	        },
+//	        {
+//	          "description": "Sedikit Bermasalah",
+//	          "id": 1,
+//	          "score": 1
+//	        },
+//	        {
+//	          "description": "Tidak bermasalah",
+//	          "id": 0,
+//	          "score": 0
+//	        }
+//	      ],
+//	      "questions": [
+//	        "Mengompol saat tidur",
+//	        "Mengompol di celana/popok",
+//	        "Buang air besar di celana/popok",
+//	        "Diare",
+//	        "Konstipasi / Sembelit",
+//	        "Gangguan Tidur",
+//	        "Makan terlalu banyak / terlalu sedikit",
+//	        "Pilihan makanan yang diinginkan sangat terbatas (extremely limited diet, picky eater)",
+//	        "Hiperaktif",
+//	        "Letargi, lemah, lesu",
+//	        "Memukul atau melukai diri sendiri",
+//	        "Memukul atau melukai orang lain",
+//	        "Destruktif",
+//	        "Sensitif terhadap suara",
+//	        "Cemas / penuh ketakutan",
+//	        "Tidak senang/ mudah rewel/ menangis",
+//	        "Kejang",
+//	        "Bicara secara obsesif",
+//	        "Kaku terhadap rutinitas",
+//	        "Berteriak / menjerit-jerit",
+//	        "Menuntut hal atau cara yang sama berulang-ulang",
+//	        "Sering gelisah / agitasi",
+//	        "Tidak peka terhadap nyeri",
+//	        "Terfokus atau sulit dialihkan dari objek atau topik tertentu",
+//	        "Gerakan repetitive (stimming, menggoyang-goyangkan bagian badan)"
+//	      ]
+//	    }
+//	  }
+//	}
 func (s *service) HandleCreatePackage() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		input := &CreatePackageInput{}
@@ -209,9 +236,10 @@ func (s *service) HandleCreatePackage() echo.HandlerFunc {
 		}
 
 		output, err := s.packageUsecase.Create(c.Request().Context(), usecase.CreatePackageInput{
-			PackageName:          input.PackageName,
-			Questionnaire:        input.Quesionnaire,
-			IndicationCategories: input.IndicationCategories,
+			PackageName:             input.PackageName,
+			Questionnaire:           input.Quesionnaire,
+			IndicationCategories:    input.IndicationCategories,
+			ImageResultAttributeKey: input.ImageResultAttributeKey,
 		})
 
 		if err != nil {

--- a/internal/repository/package.go
+++ b/internal/repository/package.go
@@ -32,19 +32,21 @@ func NewPackageRepo(db *gorm.DB) *PackageRepo {
 
 // CreatePackageInput input
 type CreatePackageInput struct {
-	UserID               uuid.UUID
-	PackageName          string
-	Questionnaire        model.Questionnaire
-	IndicationCategories model.IndicationCategories
+	UserID                  uuid.UUID
+	PackageName             string
+	Questionnaire           model.Questionnaire
+	IndicationCategories    model.IndicationCategories
+	ImageResultAttributeKey model.ImageResultAttributeKey
 }
 
 // Create insert new record of packages to the database
 func (r *PackageRepo) Create(ctx context.Context, input CreatePackageInput) (*model.Package, error) {
 	pack := &model.Package{
-		CreatedBy:            input.UserID,
-		Questionnaire:        input.Questionnaire,
-		Name:                 input.PackageName,
-		IndicationCategories: input.IndicationCategories,
+		CreatedBy:               input.UserID,
+		Questionnaire:           input.Questionnaire,
+		Name:                    input.PackageName,
+		IndicationCategories:    input.IndicationCategories,
+		ImageResultAttributeKey: input.ImageResultAttributeKey,
 	}
 
 	if err := r.db.WithContext(ctx).Create(pack).Error; err != nil {

--- a/internal/usecase/package.go
+++ b/internal/usecase/package.go
@@ -34,9 +34,10 @@ func NewPackageUsecase(packageRepo *repository.PackageRepo) *PackageUsecase {
 
 // CreatePackageInput input by embedding direcly model.Questionnaire to simplify the input anotation
 type CreatePackageInput struct {
-	PackageName          string                     `validate:"required"`
-	Questionnaire        model.Questionnaire        `validate:"required"`
-	IndicationCategories model.IndicationCategories `validate:"required,min=3"`
+	PackageName             string                        `validate:"required"`
+	Questionnaire           model.Questionnaire           `validate:"required"`
+	IndicationCategories    model.IndicationCategories    `validate:"required,min=3"`
+	ImageResultAttributeKey model.ImageResultAttributeKey `validate:"required"`
 }
 
 // Validate validate CreatePackageInput
@@ -49,7 +50,11 @@ func (cpi CreatePackageInput) Validate() error {
 		return err
 	}
 
-	return cpi.IndicationCategories.Validate()
+	if err := cpi.IndicationCategories.Validate(); err != nil {
+		return err
+	}
+
+	return cpi.ImageResultAttributeKey.Validate()
 }
 
 // CreatePackageOutput output
@@ -77,10 +82,11 @@ func (u *PackageUsecase) Create(ctx context.Context, input CreatePackageInput) (
 	}
 
 	pack, err := u.packageRepo.Create(ctx, repository.CreatePackageInput{
-		UserID:               user.ID,
-		PackageName:          input.PackageName,
-		Questionnaire:        input.Questionnaire,
-		IndicationCategories: input.IndicationCategories,
+		UserID:                  user.ID,
+		PackageName:             input.PackageName,
+		Questionnaire:           input.Questionnaire,
+		IndicationCategories:    input.IndicationCategories,
+		ImageResultAttributeKey: input.ImageResultAttributeKey,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR will allow the Admin level user to customize image result attribute, thus making the image downloaded by user after submitting questionnaire more configurable. The purpose is, but not limited to, support future multilingual.

This PR doesn't directly tied to a particular story ticket, but heavily relates to this ticket: [[US-15]](https://0ad.atlassian.net/browse/AA-64?atlOrigin=eyJpIjoiZGE5NGI5ZjZlODQ5NDE3MjhmMmQ5NTY0MDlhODU4N2UiLCJwIjoiaiJ9) Unduh Hasil Kuesioner