### PR TITLE
Feature/initialized an atec questionnaire

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -339,6 +339,58 @@ const docTemplate = `{
             }
         },
         "/v1/atec/questionnaires": {
+            "get": {
+                "description": "Used when a user wants to get an active ATEC questionnaire to be filled later",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Questionnaire"
+                ],
+                "summary": "Initialize ATEC questionnaire or get one",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "packageID",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "success response",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/rest.GetATECQuestionnaireOutput"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "When submiting questionnaire for a child, ensure using the parent's account or Admin level account. otherwise will be blocked.",
                 "consumes": [
@@ -381,60 +433,6 @@ const docTemplate = `{
                                     "properties": {
                                         "data": {
                                             "$ref": "#/definitions/rest.SubmitQuestionnaireOutput"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/rest.StandardErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Error",
-                        "schema": {
-                            "$ref": "#/definitions/rest.StandardErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/atec/questionnaires/": {
-            "get": {
-                "description": "Used when a user wants to get an active ATEC questionnaire to be filled later",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Questionnaire"
-                ],
-                "summary": "Initialize ATEC questionnaire or get one",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "name": "packageID",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "success response",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/definitions/rest.GetATECQuestionnaireOutput"
                                         }
                                     }
                                 }
@@ -1521,7 +1519,18 @@ const docTemplate = `{
             }
         },
         "rest.GetATECQuestionnaireOutput": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "questionnaire": {
+                    "$ref": "#/definitions/model.Questionnaire"
+                }
+            }
         },
         "rest.GetMyChildernOutput": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -331,6 +331,58 @@
             }
         },
         "/v1/atec/questionnaires": {
+            "get": {
+                "description": "Used when a user wants to get an active ATEC questionnaire to be filled later",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Questionnaire"
+                ],
+                "summary": "Initialize ATEC questionnaire or get one",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "packageID",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "success response",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/rest.GetATECQuestionnaireOutput"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "When submiting questionnaire for a child, ensure using the parent's account or Admin level account. otherwise will be blocked.",
                 "consumes": [
@@ -373,60 +425,6 @@
                                     "properties": {
                                         "data": {
                                             "$ref": "#/definitions/rest.SubmitQuestionnaireOutput"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/rest.StandardErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Error",
-                        "schema": {
-                            "$ref": "#/definitions/rest.StandardErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/atec/questionnaires/": {
-            "get": {
-                "description": "Used when a user wants to get an active ATEC questionnaire to be filled later",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Questionnaire"
-                ],
-                "summary": "Initialize ATEC questionnaire or get one",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "name": "packageID",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "success response",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/definitions/rest.GetATECQuestionnaireOutput"
                                         }
                                     }
                                 }
@@ -1513,7 +1511,18 @@
             }
         },
         "rest.GetATECQuestionnaireOutput": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "questionnaire": {
+                    "$ref": "#/definitions/model.Questionnaire"
+                }
+            }
         },
         "rest.GetMyChildernOutput": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -126,6 +126,13 @@ definitions:
         type: string
     type: object
   rest.GetATECQuestionnaireOutput:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      questionnaire:
+        $ref: '#/definitions/model.Questionnaire'
     type: object
   rest.GetMyChildernOutput:
     properties:
@@ -585,6 +592,38 @@ paths:
       tags:
       - ATEC Package
   /v1/atec/questionnaires:
+    get:
+      consumes:
+      - application/json
+      description: Used when a user wants to get an active ATEC questionnaire to be
+        filled later
+      parameters:
+      - in: query
+        name: packageID
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success response
+          schema:
+            allOf:
+            - $ref: '#/definitions/rest.StandardSuccessResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/rest.GetATECQuestionnaireOutput'
+              type: object
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "500":
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+      summary: Initialize ATEC questionnaire or get one
+      tags:
+      - Questionnaire
     post:
       consumes:
       - application/json
@@ -623,39 +662,6 @@ paths:
           schema:
             $ref: '#/definitions/rest.StandardErrorResponse'
       summary: Submit questionnaire result
-      tags:
-      - Questionnaire
-  /v1/atec/questionnaires/:
-    get:
-      consumes:
-      - application/json
-      description: Used when a user wants to get an active ATEC questionnaire to be
-        filled later
-      parameters:
-      - in: query
-        name: packageID
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success response
-          schema:
-            allOf:
-            - $ref: '#/definitions/rest.StandardSuccessResponse'
-            - properties:
-                data:
-                  $ref: '#/definitions/rest.GetATECQuestionnaireOutput'
-              type: object
-        "400":
-          description: Bad request
-          schema:
-            $ref: '#/definitions/rest.StandardErrorResponse'
-        "500":
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/rest.StandardErrorResponse'
-      summary: Initialize ATEC questionnaire or get one
       tags:
       - Questionnaire
   /v1/atec/questionnaires/results:

--- a/internal/delivery/rest/output.go
+++ b/internal/delivery/rest/output.go
@@ -118,6 +118,9 @@ type UpdateATECTemplateOutput struct {
 
 // GetATECQuestionnaireOutput output
 type GetATECQuestionnaireOutput struct {
+	ID            uuid.UUID           `json:"id"`
+	Questionnaire model.Questionnaire `json:"questionnaire"`
+	Name          string              `json:"name"`
 }
 
 // SearchChildernOutput output

--- a/internal/delivery/rest/package.go
+++ b/internal/delivery/rest/package.go
@@ -224,6 +224,8 @@ import (
 //	    }
 //	  }
 //	}
+//
+//nolint:lll
 func (s *service) HandleCreatePackage() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		input := &CreatePackageInput{}

--- a/internal/delivery/rest/questionnaire.go
+++ b/internal/delivery/rest/questionnaire.go
@@ -215,9 +215,34 @@ func (s *service) HandleGetMyQUestionnaireResults() echo.HandlerFunc {
 // @Success		200						{object}	StandardSuccessResponse{data=GetATECQuestionnaireOutput}	"success response"
 // @Failure		400						{object}	StandardErrorResponse										"Bad request"
 // @Failure		500						{object}	StandardErrorResponse										"Internal Error"
-// @Router			/v1/atec/questionnaires/ [get]
+// @Router			/v1/atec/questionnaires [get]
 func (s *service) HandleGetATECQuestionaire() echo.HandlerFunc {
 	return func(c echo.Context) error {
-		return c.NoContent(http.StatusNotImplemented)
+		input := &GetATECQuestionnaireInput{}
+		if err := c.Bind(input); err != nil {
+			return c.JSON(http.StatusBadRequest, StandardErrorResponse{
+				StatusCode:   http.StatusBadRequest,
+				ErrorMessage: "failed to parse input",
+				ErrorCode:    http.StatusText(http.StatusBadRequest),
+			})
+		}
+
+		output, err := s.questionnaireUsecase.HandleInitializeATECQuestionnaire(c.Request().Context(), usecase.InitializeATECQuestionnaireInput{
+			PackageID: input.PackageID,
+		})
+
+		if err != nil {
+			return usecaseErrorToRESTResponse(c, err)
+		}
+
+		return c.JSON(http.StatusOK, StandardSuccessResponse{
+			StatusCode: http.StatusOK,
+			Message:    http.StatusText(http.StatusOK),
+			Data: GetATECQuestionnaireOutput{
+				ID:            output.ID,
+				Questionnaire: output.Questionnaire,
+				Name:          output.Name,
+			},
+		})
 	}
 }

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -348,7 +348,7 @@ func (u *AuthUsecase) HandleSignup(ctx context.Context, input SignupInput) (*Sig
 					<div class="content">
 						<p>Terimakasih telah mendaftar pada layanan Autism Treatment Evaluation Checklist (ATEC). Untuk mengaktifkan akun Anda, silakan klik tombol berikut:</p>
 						<div class="btn-container">
-							<a href="%s?verification_token=%s" class="btn">Aktifkan Akun</a>
+							<a href="%s?validation_token=%s" class="btn">Aktifkan Akun</a>
 						</div>
 					</div>
 					<div class="footer">


### PR DESCRIPTION
This PR implement compliment of the existing feature, finding active questionnaire, that was implemented [here](https://github.com/luckyAkbar/atec/pull/13).

This PR allow the users to get a questionnaire, either by specifying a package id, or given the default from system. For now, the way to determine 'default' questionnaire to be given to the user is by finding the oldest active package. This decision may subject to change later.

This PR doesn't directly tied to a ticket, but heavily relates to this user story ticket: [[US-13]](https://0ad.atlassian.net/browse/AA-55?atlOrigin=eyJpIjoiMGFhNTM2NzZiMWNhNDVhYWFjMDNmM2M1YjI3NWZhZDQiLCJwIjoiaiJ9) Memilih Paket Kuesioner, especially this subtask ticket: [[ST-44]](https://0ad.atlassian.net/browse/AA-57?atlOrigin=eyJpIjoiMzI2ZTliYzAwMTM3NDM0OWFkNmQwMDczNTk4MzkzM2MiLCJwIjoiaiJ9) Membuat fungsi pada usecase layer untuk menangani permintaan pengguna terhadap paket kuesioner ATEC yang aktif