### PR TITLE
Feat/render simple webpage for account activation and reset password

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -731,6 +731,39 @@ const docTemplate = `{
             }
         },
         "/v1/auth/password": {
+            "get": {
+                "description": "After user click the link from email for reset password, he will be redirected here to change the password. This might not work in this page\nsince the returned value in this API is HTML",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Webpage's form to change user's account password",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request\"\t\"validation error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "After using init reset password method, the resulting JWT token can be used here\nto authorize the password changes.",
                 "consumes": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -723,6 +723,39 @@
             }
         },
         "/v1/auth/password": {
+            "get": {
+                "description": "After user click the link from email for reset password, he will be redirected here to change the password. This might not work in this page\nsince the returned value in this API is HTML",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Webpage's form to change user's account password",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request\"\t\"validation error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "After using init reset password method, the resulting JWT token can be used here\nto authorize the password changes.",
                 "consumes": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -851,6 +851,30 @@ paths:
       tags:
       - Authentication
   /v1/auth/password:
+    get:
+      consumes:
+      - application/x-www-form-urlencoded
+      description: |-
+        After user click the link from email for reset password, he will be redirected here to change the password. This might not work in this page
+        since the returned value in this API is HTML
+      produces:
+      - text/html
+      responses:
+        "200":
+          description: Successful response
+          schema:
+            $ref: '#/definitions/rest.StandardSuccessResponse'
+        "400":
+          description: "Bad request\"\t\"validation error"
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "500":
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+      summary: Webpage's form to change user's account password
+      tags:
+      - Authentication
     patch:
       consumes:
       - application/json

--- a/internal/delivery/rest/auth.go
+++ b/internal/delivery/rest/auth.go
@@ -383,15 +383,15 @@ func changePasswordWebpage(token string) string {
 	<body>
 		<div class="email-container">
 			<div class="header">
-				<h2>Change Password</h2>
+				<h2>Atur Ulang Kata Sandi</h2>
 			</div>
 			
 			<div class="content">
-				<p>Please enter your new password below.</p>
+				<p>Mohon masukan kata sandi baru anda di formulir di bawah ini.</p>
 				
 				<form id="passwordForm">
 					<div class="form-group">
-						<label for="password">New Password</label>
+						<label for="password">Kata Sandi</label>
 						<input type="password" id="password" name="password" required>
 						<button type="button" class="password-toggle" onclick="togglePassword('password')">
 							👁️
@@ -399,7 +399,7 @@ func changePasswordWebpage(token string) string {
 					</div>
 					
 					<div class="form-group">
-						<label for="confirmPassword">Confirm Password</label>
+						<label for="confirmPassword">Konfirmasi Kata Sandi</label>
 						<input type="password" id="confirmPassword" name="confirmPassword" required>
 						<button type="button" class="password-toggle" onclick="togglePassword('confirmPassword')">
 							👁️
@@ -420,8 +420,8 @@ func changePasswordWebpage(token string) string {
 		<!-- Modal HTML -->
 		<div id="successModal" class="modal">
 			<div class="modal-content">
-				<div class="modal-title">Password Berhasil Diubah</div>
-				<div class="modal-body">Silahkan login kembali di aplikasi dengan menggunakan akun Anda</div>
+				<div class="modal-title">Kata Sandi Berhasil Diubah</div>
+				<div class="modal-body">Silahkan <i>login</i> kembali di aplikasi dengan menggunakan akun Anda</div>
 				<button class="modal-close-btn" onclick="closeModal()">Tutup</button>
 			</div>
 		</div>
@@ -452,15 +452,15 @@ func changePasswordWebpage(token string) string {
 						
 						// Validation
 						if (password === '' || confirmPassword === '') {
-							throw new Error('Harap isi kedua kolom password!');
+							throw new Error('Harap isi kedua kolom kata sandi!');
 						}
 						
 						if (password !== confirmPassword) {
-							throw new Error('Password tidak cocok!');
+							throw new Error('kata sandi tidak cocok!');
 						}
 
 						if (password.length < 8 || confirmPassword.length < 8) {
-							throw new Error('Password minimal 8 karakter!');
+							throw new Error('kata sandi minimal 8 karakter!');
 						}
 
 						await resetPasswordAPI(password);
@@ -472,14 +472,14 @@ func changePasswordWebpage(token string) string {
 						alert(error.message);
 					} finally {
 						changePasswordBtn.disabled = false;
-						changePasswordBtn.textContent = 'Ganti Password';
+						changePasswordBtn.textContent = 'Ganti Kata Sandi';
 						changePasswordBtn.style.opacity = '1';
 						changePasswordBtn.style.cursor = 'pointer';
 					}
 				});
 			});
 
-			 // Get modal element
+			// Get modal element
 			const modal = document.getElementById('successModal');
 
 			function showModal() {

--- a/internal/delivery/rest/rest.go
+++ b/internal/delivery/rest/rest.go
@@ -51,6 +51,7 @@ func (s *service) initV1Routes() {
 	s.v1.POST("/auth/login", s.HandleLogin())
 	s.v1.PATCH("/auth/password", s.HandleInitResetPassword())
 	s.v1.POST("/auth/password", s.HandleResetPassword())
+	s.v1.GET("/auth/password", s.HandleRenderChangePasswordPage())
 
 	s.v1.POST("/atec/packages", s.HandleCreatePackage(), s.AuthMiddleware(false, true))
 	s.v1.PUT("/atec/packages/:package_id", s.HandleUpdatePackage(), s.AuthMiddleware(false, true))

--- a/internal/model/auth.go
+++ b/internal/model/auth.go
@@ -40,3 +40,7 @@ type LoginTokenClaims struct {
 
 	jwt.RegisteredClaims
 }
+
+// ChangePasswordTokenQuery is the key in the query parameters to handle
+// change password request
+const ChangePasswordTokenQuery = "change_password_token"

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -652,7 +652,7 @@ func (u *AuthUsecase) HandleInitesetPassword(ctx context.Context, input InitRese
 					<div class="content">
 						<p>Baru saja sistem menerima permintaan reset kata sandi terhadap akun Anda. Apabila Anda merasa melakukannya, silahkan klik tombol di bawah ini:</p>
 						<div class="btn-container">
-							<a href="%s?change_password_token=%s" class="btn">Reset Kata Sandi</a>
+							<a href="%s?%s=%s" class="btn">Reset Kata Sandi</a>
 						</div>
 					</div>
 					<div class="footer">
@@ -661,7 +661,7 @@ func (u *AuthUsecase) HandleInitesetPassword(ctx context.Context, input InitRese
 				</div>
 			</body>
 			</html>
-			`, config.ServerResetPasswordBaseURL(), changePassToken),
+			`, config.ServerResetPasswordBaseURL(), model.ChangePasswordTokenQuery, changePassToken),
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR will add functionality to add web page view in these routes:
1.  /v1/auth/verify [get]
2.  /v1/auth/password [get]

the first route if shown after the user click the link sent to their email after signing up. The second one is the interface for user to change their account's password which also gotten from the email.

This PR is related to these tickets:
1. [[US-1](https://0ad.atlassian.net/browse/AA-1?atlOrigin=eyJpIjoiYWE2YTA3NzIyNzQ3NGRjMTk3ZTc1YjJhN2Y1N2EzYTkiLCJwIjoiaiJ9)] Registrasi Pengguna Baru
2. [[US-3](https://0ad.atlassian.net/browse/AA-14?atlOrigin=eyJpIjoiMGJiZDljZWI1OWE0NDBlZTk5YzZjYTI5NDJhMjQ3MjkiLCJwIjoiaiJ9)] Reset Kata Sandi