### PR TITLE
feat: allow email resending on signup

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -929,6 +929,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/auth/signup/resend": {
+            "post": {
+                "description": "If something happen during account verification that cause the email not received\nor the email is lost, use this API to resend the verification email",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Resend email for account verification",
+                "parameters": [
+                    {
+                        "description": "resend signup input",
+                        "name": "resend_signup_input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.ResendVerificationInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/rest.ResendVerificationOutput"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request / validation error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/auth/verify": {
             "get": {
                 "description": "Confirmation method to ensure the email used when signup is active and owned by requester.\nIf the confirmation token is valid, the account will be activated\nand will be able to be used on login. Otherwise, the opposite will happen.",
@@ -1672,6 +1736,25 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.ResendVerificationInput": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.ResendVerificationOutput": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -921,6 +921,70 @@
                 }
             }
         },
+        "/v1/auth/signup/resend": {
+            "post": {
+                "description": "If something happen during account verification that cause the email not received\nor the email is lost, use this API to resend the verification email",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Resend email for account verification",
+                "parameters": [
+                    {
+                        "description": "resend signup input",
+                        "name": "resend_signup_input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.ResendVerificationInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/rest.ResendVerificationOutput"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request / validation error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/auth/verify": {
             "get": {
                 "description": "Confirmation method to ensure the email used when signup is active and owned by requester.\nIf the confirmation token is valid, the account will be activated\nand will be able to be used on login. Otherwise, the opposite will happen.",
@@ -1664,6 +1728,25 @@
             "type": "object",
             "properties": {
                 "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.ResendVerificationInput": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.ResendVerificationOutput": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -207,6 +207,18 @@ definitions:
       id:
         type: string
     type: object
+  rest.ResendVerificationInput:
+    properties:
+      email:
+        type: string
+    required:
+    - email
+    type: object
+  rest.ResendVerificationOutput:
+    properties:
+      message:
+        type: string
+    type: object
   rest.ResetPasswordInput:
     properties:
       new_password:
@@ -977,6 +989,47 @@ paths:
           schema:
             $ref: '#/definitions/rest.StandardErrorResponse'
       summary: Create a new account to access user only resources within this system
+      tags:
+      - Authentication
+  /v1/auth/signup/resend:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        If something happen during account verification that cause the email not received
+        or the email is lost, use this API to resend the verification email
+      parameters:
+      - description: resend signup input
+        in: body
+        name: resend_signup_input
+        required: true
+        schema:
+          $ref: '#/definitions/rest.ResendVerificationInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful response
+          schema:
+            allOf:
+            - $ref: '#/definitions/rest.StandardSuccessResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/rest.ResendVerificationOutput'
+              type: object
+        "400":
+          description: Bad request / validation error
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "429":
+          description: Too many requests
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "500":
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+      summary: Resend email for account verification
       tags:
       - Authentication
   /v1/auth/verify:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.6
 
 require (
 	github.com/go-playground/validator/v10 v10.25.0
+	github.com/go-redis/redis_rate/v10 v10.0.1
 	github.com/go-redsync/redsync/v4 v4.13.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOr
 github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
+github.com/go-redis/redis_rate/v10 v10.0.1 h1:calPxi7tVlxojKunJwQ72kwfozdy25RjA0bCj1h0MUo=
+github.com/go-redis/redis_rate/v10 v10.0.1/go.mod h1:EMiuO9+cjRkR7UvdvwMO7vbgqJkltQHtwbdIQvaBKIU=
 github.com/go-redsync/redsync/v4 v4.13.0 h1:49X6GJfnbLGaIpBBREM/zA4uIMDXKAh1NDkvQ1EkZKA=
 github.com/go-redsync/redsync/v4 v4.13.0/go.mod h1:HMW4Q224GZQz6x1Xc7040Yfgacukdzu7ifTDAKiyErQ=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,3 +152,21 @@ func RedisLockMinIdleConns() int {
 func RedisLockConnMaxLifetimeSec() int {
 	return viper.GetInt("caching.redis_lock.conn_max_lifetime_sec")
 }
+
+// ResendSignupVerificationLimiterDuration resend signup verification limiter duration.
+// If left unset or below 1 minutes, will return the default duration of 5 minutes.
+func ResendSignupVerificationLimiterDuration() time.Duration {
+	const defaultDurationMinutes = 5
+
+	const minimumDurationMinutes = 1
+
+	defaultDuration := defaultDurationMinutes * time.Minute
+	minimumDuration := minimumDurationMinutes * time.Minute
+
+	cfg := viper.GetDuration("resend_signup_verification_limiter_duration")
+	if cfg == 0 || cfg < minimumDuration {
+		return defaultDuration
+	}
+
+	return cfg
+}

--- a/internal/delivery/rest/error_handler.go
+++ b/internal/delivery/rest/error_handler.go
@@ -53,6 +53,12 @@ func usecaseErrorToRESTResponse(c echo.Context, err error) error {
 				ErrorCode:    http.StatusText(http.StatusForbidden),
 				ErrorMessage: e.Message,
 			})
+		case usecase.ErrTooManyRequests:
+			return c.JSON(http.StatusTooManyRequests, StandardErrorResponse{
+				StatusCode:   http.StatusTooManyRequests,
+				ErrorCode:    http.StatusText(http.StatusTooManyRequests),
+				ErrorMessage: e.Message,
+			})
 		}
 	}
 }

--- a/internal/delivery/rest/input.go
+++ b/internal/delivery/rest/input.go
@@ -143,3 +143,8 @@ type DownloadQuestionnaireResultInput struct {
 type GetChildStatInput struct {
 	ChildID uuid.UUID `param:"child_id" validate:"required"`
 }
+
+// ResendVerificationInput input
+type ResendVerificationInput struct {
+	Email string `json:"email" validate:"required,email"`
+}

--- a/internal/delivery/rest/output.go
+++ b/internal/delivery/rest/output.go
@@ -142,3 +142,8 @@ type SearchChildernOutput struct {
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
+
+// ResendVerificationOutput output
+type ResendVerificationOutput struct {
+	Message string `json:"message"`
+}

--- a/internal/delivery/rest/rest.go
+++ b/internal/delivery/rest/rest.go
@@ -47,6 +47,7 @@ func NewService(
 
 func (s *service) initV1Routes() {
 	s.v1.POST("/auth/signup", s.HandleSignUp())
+	s.v1.POST("/auth/signup/resend", s.HandleResendSignupVerification())
 	s.v1.GET("/auth/verify", s.HandleVerifyAccount())
 	s.v1.POST("/auth/login", s.HandleLogin())
 	s.v1.PATCH("/auth/password", s.HandleInitResetPassword())

--- a/internal/usecase/error.go
+++ b/internal/usecase/error.go
@@ -26,4 +26,6 @@ var (
 	ErrNotFound = errors.New("not found")
 
 	ErrForbidden = errors.New("forbidden")
+
+	ErrTooManyRequests = errors.New("too many requests")
 )


### PR DESCRIPTION
this PR will add new functionality related to signup process to address the problem where the user wasn't able to request retry resend email verification if something happen, e.g email sending failure, network problems, etc. That was caused the email on `users` table set to unique.

In this PR, add a new endpoint to address that problem. after users initially signup, and if resend is requested, system will try to find the users data, and performing retry sending email. whichever email link is clicked will be valid as long as the token is valid.

this PR relates to this ticket:
1. [[US-1](https://0ad.atlassian.net/browse/AA-1?atlOrigin=eyJpIjoiYTRlYWU2MTA1YjU0NGQ2YmJkOWIzM2FhODZhYmQ1MDQiLCJwIjoiaiJ9)] Registrasi Pengguna Baru

and directly solve this issue ticket: [No Resend Verification Email Feature](https://0ad.atlassian.net/browse/AA-83?atlOrigin=eyJpIjoiZGFkYTQwOWI1YzJiNDEzOTg3OTY1YjM1ODgzZjJjYWYiLCJwIjoiaiJ9)