### PR TITLE
fix: lock an unlocked package if a result is successfully written

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,7 @@ linters-settings:
     tab-width: 1
   funlen:
     lines: 200
-    statements: 50
+    statements: 55
     ignore-comments: true
   tagliatelle:
     case:

--- a/internal/repository/package.go
+++ b/internal/repository/package.go
@@ -153,6 +153,7 @@ func (r *PackageRepo) FindByID(ctx context.Context, id uuid.UUID) (*model.Packag
 // UpdatePackageInput input
 type UpdatePackageInput struct {
 	ActiveStatus *bool
+	LockStatus   *bool
 
 	Questionnaire *model.Questionnaire
 	PackageName   string
@@ -172,6 +173,10 @@ func (upi UpdatePackageInput) ToUpdateFields() map[string]interface{} {
 
 	if upi.Questionnaire != nil {
 		fields["questionnaire"] = upi.Questionnaire
+	}
+
+	if upi.LockStatus != nil {
+		fields["is_locked"] = *upi.LockStatus
 	}
 
 	return fields


### PR DESCRIPTION
this PR fix a problem where a package was never locked after a result is written based on that package