### PR TITLE
fix: add parent username on get my children

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1651,6 +1651,9 @@ const docTemplate = `{
                 "parent_user_id": {
                     "type": "string"
                 },
+                "parent_user_name": {
+                    "type": "string"
+                },
                 "updated_at": {
                     "type": "string"
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1643,6 +1643,9 @@
                 "parent_user_id": {
                     "type": "string"
                 },
+                "parent_user_name": {
+                    "type": "string"
+                },
                 "updated_at": {
                     "type": "string"
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -148,6 +148,8 @@ definitions:
         type: string
       parent_user_id:
         type: string
+      parent_user_name:
+        type: string
       updated_at:
         type: string
     type: object

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -117,7 +117,7 @@ func serverFn(cmd *cobra.Command, _ []string) {
 
 	authUsecase := usecase.NewAuthUsecase(sharedCryptor, userRepoUCAdapter, transactionControllerFactory, mailer, rateLimiter)
 	packageUsecase := usecase.NewPackageUsecase(packageRepoUCAdapter)
-	childUsecase := usecase.NewChildUsecase(childRepoUCAdapter, resultRepoUCAdapter)
+	childUsecase := usecase.NewChildUsecase(childRepoUCAdapter, resultRepoUCAdapter, userRepoUCAdapter)
 	questionnaireUsecase := usecase.NewQuestionnaireUsecase(packageRepoUCAdapter, childRepoUCAdapter, resultRepoUCAdapter, font)
 
 	initAdmin, err := cmd.Flags().GetBool("init-admin-account")

--- a/internal/delivery/rest/child.go
+++ b/internal/delivery/rest/child.go
@@ -159,13 +159,14 @@ func (s *service) HandleGetMyChildern() echo.HandlerFunc {
 
 		for _, child := range children {
 			output = append(output, GetMyChildernOutput{
-				ID:           child.ID,
-				ParentUserID: child.ParentUserID,
-				DateOfBirth:  child.DateOfBirth,
-				Gender:       child.Gender,
-				Name:         child.Name,
-				CreatedAt:    child.CreatedAt,
-				UpdatedAt:    child.UpdatedAt,
+				ID:             child.ID,
+				ParentUserID:   child.ParentUserID,
+				ParentUserName: child.ParentUsername,
+				DateOfBirth:    child.DateOfBirth,
+				Gender:         child.Gender,
+				Name:           child.Name,
+				CreatedAt:      child.CreatedAt,
+				UpdatedAt:      child.UpdatedAt,
 			})
 		}
 

--- a/internal/delivery/rest/output.go
+++ b/internal/delivery/rest/output.go
@@ -91,13 +91,14 @@ type UpdateChildernOutput struct {
 
 // GetMyChildernOutput output
 type GetMyChildernOutput struct {
-	ID           uuid.UUID `json:"id"`
-	ParentUserID uuid.UUID `json:"parent_user_id"`
-	DateOfBirth  time.Time `json:"date_of_birth"`
-	Gender       bool      `json:"gender"`
-	Name         string    `json:"name"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID             uuid.UUID `json:"id"`
+	ParentUserID   uuid.UUID `json:"parent_user_id"`
+	ParentUserName string    `json:"parent_user_name"`
+	DateOfBirth    time.Time `json:"date_of_birth"`
+	Gender         bool      `json:"gender"`
+	Name           string    `json:"name"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // CreatePackageOutput output


### PR DESCRIPTION
This PR will add new returned data on get registered children

the new sample of returned data will be:
<pre>
{
	"status_code": 200,
	"message": "OK",
	"data": [
		{
			"id": "702faa38-516d-43c3-9463-ccadddd6f469",
			"parent_user_id": "db3c1aed-3d4e-48f8-a165-a8534aa84546",
			"parent_user_name": "username", <-- the new data
			"date_of_birth": "2021-01-29T07:00:00+07:00",
			"gender": false,
			"name": "Jane Doe",
			"created_at": "2025-05-08T10:34:54.852687+07:00",
			"updated_at": "2025-05-08T10:34:54.852687+07:00"
		}
	]
}
</pre>

This PR doesn't directly tied to any ticket