### PR TITLE
fix: wrong role assignment on sign up

### DIFF
--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -249,7 +249,7 @@ func (u *AuthUsecase) HandleSignup(ctx context.Context, input SignupInput) (*Sig
 		Password: hashedPassword,
 		Username: input.Username,
 		IsActive: false,
-		Roles:    model.RolesTherapist,
+		Roles:    model.RolesParent,
 	}
 
 	txCtrl := u.transactionControllerFactory.New()

--- a/internal/usecase/auth_test.go
+++ b/internal/usecase/auth_test.go
@@ -478,7 +478,7 @@ func TestAuthUsecase_HandleSignup(t *testing.T) {
 		Password: sampleHashedPassword,
 		Username: sampleValidUsername,
 		IsActive: false,
-		Roles:    model.RolesTherapist,
+		Roles:    model.RolesParent,
 	}
 
 	uc := usecase.NewAuthUsecase(mockSharedCryptor, mockUserRepo, mockTxCtrlFactory, mockMailer, mockRateLimiter)


### PR DESCRIPTION
wrong role assigned when users sign up. it should be parents, not therapist