### PR TITLE
feat: delete user data

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -667,6 +667,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/auth/accounts": {
+            "delete": {
+                "security": [
+                    {
+                        "ParentLevelAuth": []
+                    }
+                ],
+                "description": "Delete all user's related data from the system",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Delete user's account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "JWT Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "the email of the account which password will be reset",
+                        "name": "change_password_input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.DeleteAccountInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request\"\t\"validation error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/auth/login": {
             "post": {
                 "description": "Use this endpoint to login with your username and password",
@@ -1613,6 +1671,22 @@ const docTemplate = `{
             "properties": {
                 "id": {
                     "type": "string"
+                }
+            }
+        },
+        "rest.DeleteAccountInput": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -659,6 +659,64 @@
                 }
             }
         },
+        "/v1/auth/accounts": {
+            "delete": {
+                "security": [
+                    {
+                        "ParentLevelAuth": []
+                    }
+                ],
+                "description": "Delete all user's related data from the system",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Delete user's account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "JWT Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "the email of the account which password will be reset",
+                        "name": "change_password_input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.DeleteAccountInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request\"\t\"validation error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/auth/login": {
             "post": {
                 "description": "Use this endpoint to login with your username and password",
@@ -1605,6 +1663,22 @@
             "properties": {
                 "id": {
                     "type": "string"
+                }
+            }
+        },
+        "rest.DeleteAccountInput": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -125,6 +125,17 @@ definitions:
       id:
         type: string
     type: object
+  rest.DeleteAccountInput:
+    properties:
+      email:
+        type: string
+      password:
+        minLength: 8
+        type: string
+    required:
+    - email
+    - password
+    type: object
   rest.GetATECQuestionnaireOutput:
     properties:
       id:
@@ -825,6 +836,43 @@ paths:
       summary: Get my quesionnaires results
       tags:
       - Questionnaire
+  /v1/auth/accounts:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all user's related data from the system
+      parameters:
+      - description: JWT Token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: the email of the account which password will be reset
+        in: body
+        name: change_password_input
+        required: true
+        schema:
+          $ref: '#/definitions/rest.DeleteAccountInput'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Successful response
+          schema:
+            $ref: '#/definitions/rest.StandardSuccessResponse'
+        "400":
+          description: "Bad request\"\t\"validation error"
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "500":
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+      security:
+      - ParentLevelAuth: []
+      summary: Delete user's account
+      tags:
+      - Authentication
   /v1/auth/login:
     post:
       consumes:

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -115,7 +115,15 @@ func serverFn(cmd *cobra.Command, _ []string) {
 	childRepoUCAdapter := repository.NewChildRepositoryUCAdapter(childRepo)
 	resultRepoUCAdapter := repository.NewResultRepositoryUCAdapter(resultRepo)
 
-	authUsecase := usecase.NewAuthUsecase(sharedCryptor, userRepoUCAdapter, transactionControllerFactory, mailer, rateLimiter)
+	authUsecase := usecase.NewAuthUsecase(
+		sharedCryptor,
+		userRepoUCAdapter,
+		resultRepoUCAdapter,
+		childRepoUCAdapter,
+		transactionControllerFactory,
+		mailer,
+		rateLimiter,
+	)
 	packageUsecase := usecase.NewPackageUsecase(packageRepoUCAdapter)
 	childUsecase := usecase.NewChildUsecase(childRepoUCAdapter, resultRepoUCAdapter, userRepoUCAdapter)
 	questionnaireUsecase := usecase.NewQuestionnaireUsecase(packageRepoUCAdapter, childRepoUCAdapter, resultRepoUCAdapter, font)

--- a/internal/delivery/rest/input.go
+++ b/internal/delivery/rest/input.go
@@ -148,3 +148,9 @@ type GetChildStatInput struct {
 type ResendVerificationInput struct {
 	Email string `json:"email" validate:"required,email"`
 }
+
+// DeleteAccountInput input
+type DeleteAccountInput struct {
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required,min=8"`
+}

--- a/internal/delivery/rest/rest.go
+++ b/internal/delivery/rest/rest.go
@@ -60,6 +60,7 @@ func (s *Service) initV1Routes() {
 	s.v1.PATCH("/auth/password", s.HandleInitResetPassword())
 	s.v1.POST("/auth/password", s.HandleResetPassword())
 	s.v1.GET("/auth/password", s.HandleRenderChangePasswordPage())
+	s.v1.DELETE("/auth/accounts", s.HandleDeleteAccount(), s.AuthMiddleware(false))
 
 	s.v1.POST("/atec/packages", s.HandleCreatePackage(), s.AuthMiddleware(false))
 	s.v1.PUT("/atec/packages/:package_id", s.HandleUpdatePackage(), s.AuthMiddleware(false))

--- a/internal/repository/child.go
+++ b/internal/repository/child.go
@@ -131,3 +131,22 @@ func (r *ChildRepository) Search(ctx context.Context, input usecase.RepoSearchCh
 
 	return children, nil
 }
+
+// DeleteAllUserChildren delete all children of the userID
+func (r *ChildRepository) DeleteAllUserChildren(ctx context.Context, input usecase.RepoDeleteAllUserChildrenInput, txController ...*gorm.DB) error {
+	tx := r.db
+	if len(txController) > 0 {
+		tx = txController[0]
+	}
+
+	if input.HardDelete {
+		tx = tx.Unscoped()
+	}
+
+	err := tx.WithContext(ctx).Where("parent_user_id = ?", input.UserID).Delete(&model.Child{}).Error
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/repository/usecase_adapter.go
+++ b/internal/repository/usecase_adapter.go
@@ -67,6 +67,23 @@ func (r *ChildRepositoryUCAdapter) Update(ctx context.Context, id uuid.UUID, inp
 	return res, UsecaseErrorUCAdapter(err)
 }
 
+// DeleteAllUserChildren call the repository's DeleteAllUserChildren method and convert the error to usecase error
+func (r *ChildRepositoryUCAdapter) DeleteAllUserChildren(
+	ctx context.Context,
+	input usecase.RepoDeleteAllUserChildrenInput,
+	txController ...any,
+) error {
+	if len(txController) == 0 {
+		return r.repo.DeleteAllUserChildren(ctx, input)
+	}
+
+	if tx, ok := txController[0].(*gorm.DB); ok {
+		return r.repo.DeleteAllUserChildren(ctx, input, tx)
+	}
+
+	return fmt.Errorf("%w: invalid transaction controller, expecting typeof gorm transaction", usecase.ErrRepoInternal)
+}
+
 // PackageRepositoryUCAdapter package repository usecase adapter
 type PackageRepositoryUCAdapter struct {
 	repo *PackageRepo
@@ -190,6 +207,23 @@ func (r *ResultRepositoryUCAdapter) Search(ctx context.Context, input usecase.Re
 	return res, UsecaseErrorUCAdapter(err)
 }
 
+// DeleteAllUserResults call the repository's DeleteAllUserResults method and convert the error to usecase error
+func (r *ResultRepositoryUCAdapter) DeleteAllUserResults(
+	ctx context.Context,
+	input usecase.RepoDeleteAllUserResultsInput,
+	txController ...any,
+) error {
+	if len(txController) == 0 {
+		return r.repo.DeleteAllUserResults(ctx, input)
+	}
+
+	if tx, ok := txController[0].(*gorm.DB); ok {
+		return r.repo.DeleteAllUserResults(ctx, input, tx)
+	}
+
+	return fmt.Errorf("%w: invalid transaction controller, expecting typeof gorm transaction", usecase.ErrRepoInternal)
+}
+
 // UserRepositoryUCAdapter user repository usecase adapter
 type UserRepositoryUCAdapter struct {
 	repo *UserRepository
@@ -252,4 +286,17 @@ func (r *UserRepositoryUCAdapter) Update(ctx context.Context, userID uuid.UUID, 
 	res, err := r.repo.Update(ctx, userID, input)
 
 	return res, UsecaseErrorUCAdapter(err)
+}
+
+// DeleteByID call the repository's DeleteByID method and convert the error to usecase error
+func (r *UserRepositoryUCAdapter) DeleteByID(ctx context.Context, input usecase.RepoDeleteUserByIDInput, txController ...any) error {
+	if len(txController) == 0 {
+		return r.repo.DeleteByID(ctx, input)
+	}
+
+	if tx, ok := txController[0].(*gorm.DB); ok {
+		return r.repo.DeleteByID(ctx, input, tx)
+	}
+
+	return fmt.Errorf("%w: invalid transaction controller, expecting typeof gorm transaction", usecase.ErrRepoInternal)
 }

--- a/internal/repository/usecase_adapter_test.go
+++ b/internal/repository/usecase_adapter_test.go
@@ -110,6 +110,50 @@ func TestChildRepositoryUCAdapter(t *testing.T) {
 		_, err := adapter.Update(ctx, childID, usecase.RepoUpdateChildInput{})
 		assert.NoError(t, err)
 	})
+
+	t.Run("DeleteAllUserChildren", func(t *testing.T) {
+		userID := uuid.New()
+
+		dbMock.ExpectBegin()
+
+		dbMock.ExpectExec("^DELETE FROM \"children\"").
+			WithArgs(userID).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		dbMock.ExpectCommit()
+
+		err := adapter.DeleteAllUserChildren(ctx, usecase.RepoDeleteAllUserChildrenInput{
+			UserID:     userID,
+			HardDelete: true,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteAllUserChildren with custom tx", func(t *testing.T) {
+		userID := uuid.New()
+
+		dbMock.ExpectBegin()
+
+		dbMock.ExpectExec("^DELETE FROM \"children\"").
+			WithArgs(userID).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		dbMock.ExpectCommit()
+
+		err := adapter.DeleteAllUserChildren(ctx, usecase.RepoDeleteAllUserChildrenInput{
+			UserID:     userID,
+			HardDelete: true,
+		}, kit.DB)
+		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteAllUserChildren with invalid tx", func(t *testing.T) {
+		err := adapter.DeleteAllUserChildren(ctx, usecase.RepoDeleteAllUserChildrenInput{
+			UserID:     uuid.New(),
+			HardDelete: true,
+		}, 1)
+		assert.Error(t, err)
+	})
 }
 
 func TestPackageRepositoryUCAdapter(t *testing.T) {
@@ -268,6 +312,50 @@ func TestResultRepositoryUCAdapter(t *testing.T) {
 		_, err := adapter.Search(ctx, usecase.RepoSearchResultInput{})
 		require.Error(t, err)
 	})
+
+	t.Run("DeleteAllUserResults", func(t *testing.T) {
+		userID := uuid.New()
+
+		dbMock.ExpectBegin()
+
+		dbMock.ExpectExec("^DELETE FROM \"results\"").
+			WithArgs(userID, userID).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		dbMock.ExpectCommit()
+
+		err := adapter.DeleteAllUserResults(ctx, usecase.RepoDeleteAllUserResultsInput{
+			UserID:     userID,
+			HardDelete: true,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("DeleteAllUserResults with custom tx", func(t *testing.T) {
+		userID := uuid.New()
+
+		dbMock.ExpectBegin()
+
+		dbMock.ExpectExec("^DELETE FROM \"results\"").
+			WithArgs(userID, userID).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		dbMock.ExpectCommit()
+
+		err := adapter.DeleteAllUserResults(ctx, usecase.RepoDeleteAllUserResultsInput{
+			UserID:     userID,
+			HardDelete: true,
+		}, kit.DB)
+		require.NoError(t, err)
+	})
+
+	t.Run("DeleteAllUserResults with invalid tx", func(t *testing.T) {
+		err := adapter.DeleteAllUserResults(ctx, usecase.RepoDeleteAllUserResultsInput{
+			UserID:     uuid.New(),
+			HardDelete: true,
+		}, 1)
+		assert.Error(t, err)
+	})
 }
 
 func TestUserRepositoryUCAdapter(t *testing.T) {
@@ -374,5 +462,48 @@ func TestUserRepositoryUCAdapter(t *testing.T) {
 			IsActive: &isActive,
 		})
 		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteByID - ok", func(t *testing.T) {
+		userID := uuid.New()
+
+		dbMock.ExpectBegin()
+
+		dbMock.ExpectExec("^DELETE FROM \"users\"").
+			WithArgs(userID).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		dbMock.ExpectCommit()
+
+		err := adapter.DeleteByID(ctx, usecase.RepoDeleteUserByIDInput{
+			UserID:     userID,
+			HardDelete: true,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteByID with custom tx", func(t *testing.T) {
+		userID := uuid.New()
+
+		dbMock.ExpectBegin()
+
+		dbMock.ExpectExec("^DELETE FROM \"users\"").
+			WithArgs(userID).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		dbMock.ExpectCommit()
+
+		err := adapter.DeleteByID(ctx, usecase.RepoDeleteUserByIDInput{
+			UserID:     userID,
+			HardDelete: true,
+		}, kit.DB)
+		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteByID with invalid tx", func(t *testing.T) {
+		err := adapter.DeleteByID(ctx, usecase.RepoDeleteUserByIDInput{
+			UserID: uuid.New(),
+		}, 1)
+		assert.Error(t, err)
 	})
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -157,3 +157,22 @@ func (r *UserRepository) Search(ctx context.Context, input usecase.RepoSearchUse
 
 	return users, nil
 }
+
+// DeleteByID delete a user by its id
+func (r *UserRepository) DeleteByID(ctx context.Context, input usecase.RepoDeleteUserByIDInput, txController ...*gorm.DB) error {
+	tx := r.db
+	if len(txController) > 0 {
+		tx = txController[0]
+	}
+
+	if input.HardDelete {
+		tx = tx.Unscoped()
+	}
+
+	err := tx.WithContext(ctx).Where("id = ?", input.UserID).Delete(&model.User{}).Error
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -512,3 +512,81 @@ func TestUserRepository_Search(t *testing.T) {
 		})
 	}
 }
+
+func TestUserRepository_DeleteByID(t *testing.T) {
+	ctx := context.Background()
+	kit, closer := InitializeRepoTestKit(t)
+
+	defer closer()
+
+	dbMock := kit.DBmock
+	repo := repository.NewUserRepository(kit.DB)
+
+	userID := uuid.New()
+
+	testCases := []struct {
+		name                 string
+		input                usecase.RepoDeleteUserByIDInput
+		wantErr              bool
+		expectedErr          error
+		expectedFunctionCall func()
+	}{
+		{
+			name: "success",
+			input: usecase.RepoDeleteUserByIDInput{
+				UserID:     userID,
+				HardDelete: true,
+			},
+			wantErr: false,
+			expectedFunctionCall: func() {
+				dbMock.ExpectBegin()
+
+				dbMock.ExpectExec("^DELETE FROM \"users\"").
+					WithArgs(userID).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+
+				dbMock.ExpectCommit()
+			},
+		},
+		{
+			name: "error - hard delete",
+			input: usecase.RepoDeleteUserByIDInput{
+				UserID:     userID,
+				HardDelete: true,
+			},
+			wantErr:     true,
+			expectedErr: assert.AnError,
+			expectedFunctionCall: func() {
+				dbMock.ExpectBegin()
+
+				dbMock.ExpectExec("^DELETE FROM \"users\"").
+					WithArgs(userID).
+					WillReturnError(assert.AnError)
+
+				dbMock.ExpectRollback()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedFunctionCall != nil {
+				tc.expectedFunctionCall()
+			}
+
+			err := repo.DeleteByID(ctx, tc.input, kit.DB)
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				if tc.expectedErr != nil {
+					assert.Equal(t, tc.expectedErr, err)
+				}
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/usecase/repository.go
+++ b/internal/usecase/repository.go
@@ -93,6 +93,7 @@ type ChildRepository interface {
 	Update(ctx context.Context, id uuid.UUID, input RepoUpdateChildInput) (*model.Child, error)
 	FindByID(ctx context.Context, id uuid.UUID) (*model.Child, error)
 	Search(ctx context.Context, input RepoSearchChildInput) ([]model.Child, error)
+	DeleteAllUserChildren(ctx context.Context, input RepoDeleteAllUserChildrenInput, txController ...any) error
 }
 
 // RepoRegisterChildInput input
@@ -141,6 +142,7 @@ type UserRepository interface {
 	Update(ctx context.Context, userID uuid.UUID, input RepoUpdateUserInput) (*model.User, error)
 	Search(ctx context.Context, input RepoSearchUserInput) ([]model.User, error)
 	IsAdminAccountExists(ctx context.Context) (bool, error)
+	DeleteByID(ctx context.Context, input RepoDeleteUserByIDInput, txController ...any) error
 }
 
 // RepoCreateResultInput create result input
@@ -175,6 +177,7 @@ type ResultRepository interface {
 	FindByID(ctx context.Context, id uuid.UUID) (*model.Result, error)
 	Search(ctx context.Context, input RepoSearchResultInput) ([]model.Result, error)
 	FindAllUserHistory(ctx context.Context, input RepoFindAllUserHistoryInput) ([]model.Result, error)
+	DeleteAllUserResults(ctx context.Context, input RepoDeleteAllUserResultsInput, txController ...any) error
 }
 
 // RepoCreatePackageInput input
@@ -199,6 +202,24 @@ type RepoUpdatePackageInput struct {
 type RepoSearchPackageInput struct {
 	IsActive *bool
 	Limit    int
+}
+
+// RepoDeleteAllUserResultsInput input
+type RepoDeleteAllUserResultsInput struct {
+	UserID     uuid.UUID
+	HardDelete bool
+}
+
+// RepoDeleteAllUserChildrenInput input
+type RepoDeleteAllUserChildrenInput struct {
+	UserID     uuid.UUID
+	HardDelete bool
+}
+
+// RepoDeleteUserByIDInput input
+type RepoDeleteUserByIDInput struct {
+	UserID     uuid.UUID
+	HardDelete bool
 }
 
 // PackageRepo interface for PackageRepo

--- a/mocks/internal_/usecase/AuthUsecaseIface.go
+++ b/mocks/internal_/usecase/AuthUsecaseIface.go
@@ -140,6 +140,53 @@ func (_c *AuthUsecaseIface_HandleAccountVerification_Call) RunAndReturn(run func
 	return _c
 }
 
+// HandleDeleteUserData provides a mock function with given fields: ctx, input
+func (_m *AuthUsecaseIface) HandleDeleteUserData(ctx context.Context, input usecase.DeleteUserDataInput) error {
+	ret := _m.Called(ctx, input)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HandleDeleteUserData")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, usecase.DeleteUserDataInput) error); ok {
+		r0 = rf(ctx, input)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// AuthUsecaseIface_HandleDeleteUserData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HandleDeleteUserData'
+type AuthUsecaseIface_HandleDeleteUserData_Call struct {
+	*mock.Call
+}
+
+// HandleDeleteUserData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - input usecase.DeleteUserDataInput
+func (_e *AuthUsecaseIface_Expecter) HandleDeleteUserData(ctx interface{}, input interface{}) *AuthUsecaseIface_HandleDeleteUserData_Call {
+	return &AuthUsecaseIface_HandleDeleteUserData_Call{Call: _e.mock.On("HandleDeleteUserData", ctx, input)}
+}
+
+func (_c *AuthUsecaseIface_HandleDeleteUserData_Call) Run(run func(ctx context.Context, input usecase.DeleteUserDataInput)) *AuthUsecaseIface_HandleDeleteUserData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(usecase.DeleteUserDataInput))
+	})
+	return _c
+}
+
+func (_c *AuthUsecaseIface_HandleDeleteUserData_Call) Return(_a0 error) *AuthUsecaseIface_HandleDeleteUserData_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *AuthUsecaseIface_HandleDeleteUserData_Call) RunAndReturn(run func(context.Context, usecase.DeleteUserDataInput) error) *AuthUsecaseIface_HandleDeleteUserData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HandleInitesetPassword provides a mock function with given fields: ctx, input
 func (_m *AuthUsecaseIface) HandleInitesetPassword(ctx context.Context, input usecase.InitResetPasswordInput) (*usecase.InitResetPasswordOutput, error) {
 	ret := _m.Called(ctx, input)

--- a/mocks/internal_/usecase/ChildRepository.go
+++ b/mocks/internal_/usecase/ChildRepository.go
@@ -85,6 +85,64 @@ func (_c *ChildRepository_Create_Call) RunAndReturn(run func(context.Context, us
 	return _c
 }
 
+// DeleteAllUserChildren provides a mock function with given fields: ctx, input, txController
+func (_m *ChildRepository) DeleteAllUserChildren(ctx context.Context, input usecase.RepoDeleteAllUserChildrenInput, txController ...any) error {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, input)
+	_ca = append(_ca, txController...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllUserChildren")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, usecase.RepoDeleteAllUserChildrenInput, ...any) error); ok {
+		r0 = rf(ctx, input, txController...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ChildRepository_DeleteAllUserChildren_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllUserChildren'
+type ChildRepository_DeleteAllUserChildren_Call struct {
+	*mock.Call
+}
+
+// DeleteAllUserChildren is a helper method to define mock.On call
+//   - ctx context.Context
+//   - input usecase.RepoDeleteAllUserChildrenInput
+//   - txController ...any
+func (_e *ChildRepository_Expecter) DeleteAllUserChildren(ctx interface{}, input interface{}, txController ...interface{}) *ChildRepository_DeleteAllUserChildren_Call {
+	return &ChildRepository_DeleteAllUserChildren_Call{Call: _e.mock.On("DeleteAllUserChildren",
+		append([]interface{}{ctx, input}, txController...)...)}
+}
+
+func (_c *ChildRepository_DeleteAllUserChildren_Call) Run(run func(ctx context.Context, input usecase.RepoDeleteAllUserChildrenInput, txController ...any)) *ChildRepository_DeleteAllUserChildren_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(args[0].(context.Context), args[1].(usecase.RepoDeleteAllUserChildrenInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ChildRepository_DeleteAllUserChildren_Call) Return(_a0 error) *ChildRepository_DeleteAllUserChildren_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ChildRepository_DeleteAllUserChildren_Call) RunAndReturn(run func(context.Context, usecase.RepoDeleteAllUserChildrenInput, ...any) error) *ChildRepository_DeleteAllUserChildren_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindByID provides a mock function with given fields: ctx, id
 func (_m *ChildRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Child, error) {
 	ret := _m.Called(ctx, id)

--- a/mocks/internal_/usecase/ResultRepository.go
+++ b/mocks/internal_/usecase/ResultRepository.go
@@ -85,6 +85,64 @@ func (_c *ResultRepository_Create_Call) RunAndReturn(run func(context.Context, u
 	return _c
 }
 
+// DeleteAllUserResults provides a mock function with given fields: ctx, input, txController
+func (_m *ResultRepository) DeleteAllUserResults(ctx context.Context, input usecase.RepoDeleteAllUserResultsInput, txController ...any) error {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, input)
+	_ca = append(_ca, txController...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllUserResults")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, usecase.RepoDeleteAllUserResultsInput, ...any) error); ok {
+		r0 = rf(ctx, input, txController...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ResultRepository_DeleteAllUserResults_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllUserResults'
+type ResultRepository_DeleteAllUserResults_Call struct {
+	*mock.Call
+}
+
+// DeleteAllUserResults is a helper method to define mock.On call
+//   - ctx context.Context
+//   - input usecase.RepoDeleteAllUserResultsInput
+//   - txController ...any
+func (_e *ResultRepository_Expecter) DeleteAllUserResults(ctx interface{}, input interface{}, txController ...interface{}) *ResultRepository_DeleteAllUserResults_Call {
+	return &ResultRepository_DeleteAllUserResults_Call{Call: _e.mock.On("DeleteAllUserResults",
+		append([]interface{}{ctx, input}, txController...)...)}
+}
+
+func (_c *ResultRepository_DeleteAllUserResults_Call) Run(run func(ctx context.Context, input usecase.RepoDeleteAllUserResultsInput, txController ...any)) *ResultRepository_DeleteAllUserResults_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(args[0].(context.Context), args[1].(usecase.RepoDeleteAllUserResultsInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ResultRepository_DeleteAllUserResults_Call) Return(_a0 error) *ResultRepository_DeleteAllUserResults_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ResultRepository_DeleteAllUserResults_Call) RunAndReturn(run func(context.Context, usecase.RepoDeleteAllUserResultsInput, ...any) error) *ResultRepository_DeleteAllUserResults_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindAllUserHistory provides a mock function with given fields: ctx, input
 func (_m *ResultRepository) FindAllUserHistory(ctx context.Context, input usecase.RepoFindAllUserHistoryInput) ([]model.Result, error) {
 	ret := _m.Called(ctx, input)

--- a/mocks/internal_/usecase/UserRepository.go
+++ b/mocks/internal_/usecase/UserRepository.go
@@ -96,6 +96,64 @@ func (_c *UserRepository_Create_Call) RunAndReturn(run func(context.Context, use
 	return _c
 }
 
+// DeleteByID provides a mock function with given fields: ctx, input, txController
+func (_m *UserRepository) DeleteByID(ctx context.Context, input usecase.RepoDeleteUserByIDInput, txController ...any) error {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, input)
+	_ca = append(_ca, txController...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteByID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, usecase.RepoDeleteUserByIDInput, ...any) error); ok {
+		r0 = rf(ctx, input, txController...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UserRepository_DeleteByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteByID'
+type UserRepository_DeleteByID_Call struct {
+	*mock.Call
+}
+
+// DeleteByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - input usecase.RepoDeleteUserByIDInput
+//   - txController ...any
+func (_e *UserRepository_Expecter) DeleteByID(ctx interface{}, input interface{}, txController ...interface{}) *UserRepository_DeleteByID_Call {
+	return &UserRepository_DeleteByID_Call{Call: _e.mock.On("DeleteByID",
+		append([]interface{}{ctx, input}, txController...)...)}
+}
+
+func (_c *UserRepository_DeleteByID_Call) Run(run func(ctx context.Context, input usecase.RepoDeleteUserByIDInput, txController ...any)) *UserRepository_DeleteByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]any, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(any)
+			}
+		}
+		run(args[0].(context.Context), args[1].(usecase.RepoDeleteUserByIDInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *UserRepository_DeleteByID_Call) Return(_a0 error) *UserRepository_DeleteByID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *UserRepository_DeleteByID_Call) RunAndReturn(run func(context.Context, usecase.RepoDeleteUserByIDInput, ...any) error) *UserRepository_DeleteByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindByEmail provides a mock function with given fields: ctx, email
 func (_m *UserRepository) FindByEmail(ctx context.Context, email string) (*model.User, error) {
 	ret := _m.Called(ctx, email)


### PR DESCRIPTION
This PR will add functionality to delete the user's generated data from the system.

The deleted data including:
1. user's submitted questionnaire
2. children data
3. account record

this PR solves all the ticket under story [US - 19](https://0ad.atlassian.net/browse/AA-85?atlOrigin=eyJpIjoiNGQxMjZmZTIzYmUwNGRjY2FhMTM3MDE2ODkwNTQxMmUiLCJwIjoiaiJ9)

unit test:
<pre>
make unit-tests
        github.com/luckyAkbar/atec              coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/common              coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/config              coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/db          coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/console             coverage: 0.0% of statements
ok      github.com/luckyAkbar/atec/internal/delivery/rest       1.121s  coverage: 98.9% of statements
ok      github.com/luckyAkbar/atec/internal/model       1.074s  coverage: 99.1% of statements
ok      github.com/luckyAkbar/atec/internal/repository  1.196s  coverage: 79.9% of statements
ok      github.com/luckyAkbar/atec/internal/usecase     1.822s  coverage: 95.4% of statements
</pre>