### PR TITLE
feat: get all therapists user / data

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1557,6 +1557,76 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/v1/users/therapists": {
+            "get": {
+                "security": [
+                    {
+                        "ParentLevelAuth": []
+                    }
+                ],
+                "description": "Return the list of all users with therapist role",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get all therapists",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "JWT Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/rest.GetTherapistOutput"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1817,6 +1887,29 @@ const docTemplate = `{
             }
         },
         "rest.GetMyProfileOutput": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "roles": {
+                    "$ref": "#/definitions/model.Roles"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.GetTherapistOutput": {
             "type": "object",
             "properties": {
                 "created_at": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1549,6 +1549,76 @@
                     }
                 }
             }
+        },
+        "/v1/users/therapists": {
+            "get": {
+                "security": [
+                    {
+                        "ParentLevelAuth": []
+                    }
+                ],
+                "description": "Return the list of all users with therapist role",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get all therapists",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "JWT Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/rest.StandardSuccessResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/rest.GetTherapistOutput"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.StandardErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1809,6 +1879,29 @@
             }
         },
         "rest.GetMyProfileOutput": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "roles": {
+                    "$ref": "#/definitions/model.Roles"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.GetTherapistOutput": {
             "type": "object",
             "properties": {
                 "created_at": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -191,6 +191,21 @@ definitions:
       username:
         type: string
     type: object
+  rest.GetTherapistOutput:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      is_active:
+        type: boolean
+      roles:
+        $ref: '#/definitions/model.Roles'
+      updated_at:
+        type: string
+      username:
+        type: string
+    type: object
   rest.InitResetPasswordInput:
     properties:
       email:
@@ -1426,6 +1441,48 @@ paths:
       security:
       - ParentLevelAuth: []
       summary: Get my profile data
+      tags:
+      - Users
+  /v1/users/therapists:
+    get:
+      consumes:
+      - application/json
+      description: Return the list of all users with therapist role
+      parameters:
+      - description: JWT Token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful response
+          schema:
+            allOf:
+            - $ref: '#/definitions/rest.StandardSuccessResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/rest.GetTherapistOutput'
+                  type: array
+              type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+        "500":
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/rest.StandardErrorResponse'
+      security:
+      - ParentLevelAuth: []
+      summary: Get all therapists
       tags:
       - Users
 securityDefinitions:

--- a/internal/delivery/rest/output.go
+++ b/internal/delivery/rest/output.go
@@ -160,3 +160,13 @@ type GetMyProfileOutput struct {
 	CreatedAt time.Time   `json:"created_at"`
 	UpdatedAt time.Time   `json:"updated_at"`
 }
+
+// GetTherapistOutput output
+type GetTherapistOutput struct {
+	ID        uuid.UUID   `json:"id"`
+	Username  string      `json:"username"`
+	IsActive  bool        `json:"is_active"`
+	Roles     model.Roles `json:"roles"`
+	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
+}

--- a/internal/delivery/rest/rest.go
+++ b/internal/delivery/rest/rest.go
@@ -88,6 +88,8 @@ func (s *Service) initV1Routes() {
 
 	s.v1.GET("/me", s.HandleGetMyProfile(), s.AuthMiddleware(false))
 
+	s.v1.GET("/users/therapists", s.HandleGetTherapists(), s.AuthMiddleware(false))
+
 	s.v1.GET("/swagger/*", echoSwagger.WrapHandler)
 }
 

--- a/internal/delivery/rest/users.go
+++ b/internal/delivery/rest/users.go
@@ -39,3 +39,42 @@ func (s *Service) HandleGetMyProfile() echo.HandlerFunc {
 		})
 	}
 }
+
+// @Summary		Get all therapists
+// @Description	Return the list of all users with therapist role
+// @Tags			Users
+// @Accept			json
+// @Produce		json
+// @Security		ParentLevelAuth
+// @Param			Authorization	header		string												true	"JWT Token"
+// @Success		200				{object}	StandardSuccessResponse{data=[]GetTherapistOutput}	"Successful response"
+// @Failure		401				{object}	StandardErrorResponse								"Unauthorized"
+// @Failure		404				{object}	StandardErrorResponse								"Not Found"
+// @Failure		500				{object}	StandardErrorResponse								"Internal Error"
+// @Router			/v1/users/therapists [get]
+func (s *Service) HandleGetTherapists() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		output, err := s.usersUsecase.GetTherapistData(c.Request().Context())
+		if err != nil {
+			return UsecaseErrorToRESTResponse(c, err)
+		}
+
+		resp := make([]GetTherapistOutput, 0, len(output))
+		for _, therapist := range output {
+			resp = append(resp, GetTherapistOutput{
+				ID:        therapist.ID,
+				Username:  therapist.Username,
+				IsActive:  therapist.IsActive,
+				Roles:     therapist.Roles,
+				CreatedAt: therapist.CreatedAt,
+				UpdatedAt: therapist.UpdatedAt,
+			})
+		}
+
+		return c.JSON(http.StatusOK, StandardSuccessResponse{
+			StatusCode: http.StatusOK,
+			Message:    http.StatusText(http.StatusOK),
+			Data:       resp,
+		})
+	}
+}

--- a/internal/repository/usecase_adapter.go
+++ b/internal/repository/usecase_adapter.go
@@ -300,3 +300,10 @@ func (r *UserRepositoryUCAdapter) DeleteByID(ctx context.Context, input usecase.
 
 	return fmt.Errorf("%w: invalid transaction controller, expecting typeof gorm transaction", usecase.ErrRepoInternal)
 }
+
+// GetUsersByRoles call the repository's GetUsersByRoles method and convert the error to usecase error
+func (r *UserRepositoryUCAdapter) GetUsersByRoles(ctx context.Context, roles model.Roles) ([]model.User, error) {
+	res, err := r.repo.GetUsersByRoles(ctx, roles)
+
+	return res, UsecaseErrorUCAdapter(err)
+}

--- a/internal/repository/usecase_adapter_test.go
+++ b/internal/repository/usecase_adapter_test.go
@@ -440,6 +440,17 @@ func TestUserRepositoryUCAdapter(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("GetUsersByRoles - ok", func(t *testing.T) {
+		role := model.RolesTherapist
+
+		dbMock.ExpectQuery(`^SELECT .+ FROM "users"`).
+			WithArgs(role).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()).AddRow(uuid.New()))
+
+		_, err := adapter.GetUsersByRoles(ctx, role)
+		assert.NoError(t, err)
+	})
+
 	t.Run("Update - ok", func(t *testing.T) {
 		userID := uuid.New()
 		email := "test@email.com"

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -158,6 +158,20 @@ func (r *UserRepository) Search(ctx context.Context, input usecase.RepoSearchUse
 	return users, nil
 }
 
+// GetUsersByRoles returns all users with the specified role
+func (r *UserRepository) GetUsersByRoles(ctx context.Context, roles model.Roles) ([]model.User, error) {
+	users := []model.User{}
+	if err := r.db.WithContext(ctx).Where("roles = ?", roles).Find(&users).Error; err != nil {
+		return nil, err
+	}
+
+	if len(users) == 0 {
+		return nil, ErrNotFound
+	}
+
+	return users, nil
+}
+
 // DeleteByID delete a user by its id
 func (r *UserRepository) DeleteByID(ctx context.Context, input usecase.RepoDeleteUserByIDInput, txController ...*gorm.DB) error {
 	tx := r.db

--- a/internal/usecase/repository.go
+++ b/internal/usecase/repository.go
@@ -145,6 +145,7 @@ type UserRepository interface {
 	FindByID(ctx context.Context, id uuid.UUID) (*model.User, error)
 	Update(ctx context.Context, userID uuid.UUID, input RepoUpdateUserInput) (*model.User, error)
 	Search(ctx context.Context, input RepoSearchUserInput) ([]model.User, error)
+	GetUsersByRoles(ctx context.Context, roles model.Roles) ([]model.User, error)
 	IsAdminAccountExists(ctx context.Context) (bool, error)
 	DeleteByID(ctx context.Context, input RepoDeleteUserByIDInput, txController ...any) error
 }

--- a/internal/usecase/users.go
+++ b/internal/usecase/users.go
@@ -16,6 +16,7 @@ type UsersUsecase struct {
 // UsersUsecaseIface exported interface for UsersUsecase
 type UsersUsecaseIface interface {
 	GetMyProfile(ctx context.Context) (*GetMyProfileOutput, error)
+	GetTherapistData(ctx context.Context) ([]GetTherapistDataOutput, error)
 }
 
 // NewUsersUsecase create new UsersUsecase instance
@@ -67,4 +68,55 @@ func (u *UsersUsecase) GetMyProfile(ctx context.Context) (*GetMyProfileOutput, e
 		CreatedAt: user.CreatedAt,
 		UpdatedAt: user.UpdatedAt,
 	}, nil
+}
+
+// GetTherapistDataOutput output
+type GetTherapistDataOutput struct {
+	ID        uuid.UUID
+	Username  string
+	IsActive  bool
+	Roles     model.Roles
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// GetTherapistData returns all users that have therapist role
+func (u *UsersUsecase) GetTherapistData(ctx context.Context) ([]GetTherapistDataOutput, error) {
+	requester := model.GetUserFromCtx(ctx)
+	if requester == nil {
+		return nil, UsecaseError{
+			ErrType: ErrUnauthorized,
+			Message: ErrUnauthorized.Error(),
+		}
+	}
+
+	users, err := u.userRepo.GetUsersByRoles(ctx, model.RolesTherapist)
+	if err != nil {
+		switch err {
+		default:
+			return nil, UsecaseError{
+				ErrType: ErrInternal,
+				Message: ErrInternal.Error(),
+			}
+		case ErrRepoNotFound:
+			return nil, UsecaseError{
+				ErrType: ErrNotFound,
+				Message: ErrNotFound.Error(),
+			}
+		}
+	}
+
+	output := make([]GetTherapistDataOutput, 0, len(users))
+	for _, user := range users {
+		output = append(output, GetTherapistDataOutput{
+			ID:        user.ID,
+			Username:  user.Username,
+			IsActive:  user.IsActive,
+			Roles:     user.Roles,
+			CreatedAt: user.CreatedAt,
+			UpdatedAt: user.UpdatedAt,
+		})
+	}
+
+	return output, nil
 }

--- a/internal/usecase/users_test.go
+++ b/internal/usecase/users_test.go
@@ -90,3 +90,147 @@ func TestUsersUsecase_GetMyProfile(t *testing.T) {
 		assert.WithinDuration(t, user.UpdatedAt, res.UpdatedAt, time.Second)
 	})
 }
+
+func TestUsersUsecase_GetTherapistData(t *testing.T) {
+	ctx := context.Background()
+
+	mockUserRepo := mock_usecase.NewUserRepository(t)
+	usersUsecase := usecase.NewUsersUsecase(mockUserRepo)
+
+	now := time.Now()
+
+	ctxInternal := func() context.Context {
+		requester := model.AuthUser{ID: uuid.New(), Role: model.RolesParent}
+
+		return model.SetUserToCtx(ctx, requester)
+	}()
+	ctxNotFound := func() context.Context {
+		requester := model.AuthUser{ID: uuid.New(), Role: model.RolesParent}
+
+		return model.SetUserToCtx(ctx, requester)
+	}()
+	ctxSuccess := func() context.Context {
+		requester := model.AuthUser{ID: uuid.New(), Role: model.RolesParent}
+
+		return model.SetUserToCtx(ctx, requester)
+	}()
+
+	testCases := []struct {
+		name                 string
+		ctx                  context.Context
+		wantErr              bool
+		expectedErr          error
+		expectedOutput       []usecase.GetTherapistDataOutput
+		expectedFunctionCall func()
+	}{
+		{
+			name:                 "unauthorized when requester not in context",
+			ctx:                  ctx,
+			wantErr:              true,
+			expectedErr:          usecase.ErrUnauthorized,
+			expectedFunctionCall: func() {},
+		},
+		{
+			name:        "repo error translated to internal error",
+			ctx:         ctxInternal,
+			wantErr:     true,
+			expectedErr: usecase.ErrInternal,
+			expectedFunctionCall: func() {
+				mockUserRepo.EXPECT().GetUsersByRoles(ctxInternal, model.RolesTherapist).Return(nil, usecase.ErrRepoInternal).Once()
+			},
+		},
+		{
+			name:        "repo not found translated to usecase not found",
+			ctx:         ctxNotFound,
+			wantErr:     true,
+			expectedErr: usecase.ErrNotFound,
+			expectedFunctionCall: func() {
+				mockUserRepo.EXPECT().GetUsersByRoles(ctxNotFound, model.RolesTherapist).Return(nil, usecase.ErrRepoNotFound).Once()
+			},
+		},
+		{
+			name:    "success",
+			ctx:     ctxSuccess,
+			wantErr: false,
+			expectedFunctionCall: func() {
+				users := []model.User{
+					{
+						ID:        uuid.New(),
+						Username:  "t1",
+						IsActive:  true,
+						Roles:     model.RolesTherapist,
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+					{
+						ID:        uuid.New(),
+						Username:  "t2",
+						IsActive:  false,
+						Roles:     model.RolesTherapist,
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+				}
+
+				mockUserRepo.EXPECT().GetUsersByRoles(ctxSuccess, model.RolesTherapist).Return(users, nil).Once()
+			},
+			expectedOutput: []usecase.GetTherapistDataOutput{
+				{
+					Username:  "t1",
+					IsActive:  true,
+					Roles:     model.RolesTherapist,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					Username:  "t2",
+					IsActive:  false,
+					Roles:     model.RolesTherapist,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedFunctionCall != nil {
+				tc.expectedFunctionCall()
+			}
+
+			res, err := usersUsecase.GetTherapistData(tc.ctx)
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				if tc.expectedErr != nil {
+					ucErr, ok := err.(usecase.UsecaseError)
+					require.True(t, ok)
+					assert.Equal(t, tc.expectedErr, ucErr.ErrType)
+				}
+
+				assert.Nil(t, res)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Len(t, res, len(tc.expectedOutput))
+
+			for i := range tc.expectedOutput {
+				exp := tc.expectedOutput[i]
+				got := res[i]
+
+				assert.Equal(t, exp.Username, got.Username)
+				assert.Equal(t, exp.IsActive, got.IsActive)
+				assert.Equal(t, exp.Roles, got.Roles)
+				assert.WithinDuration(t, exp.CreatedAt, got.CreatedAt, time.Second)
+				assert.WithinDuration(t, exp.UpdatedAt, got.UpdatedAt, time.Second)
+			}
+		})
+	}
+}

--- a/mocks/internal_/usecase/UserRepository.go
+++ b/mocks/internal_/usecase/UserRepository.go
@@ -272,6 +272,65 @@ func (_c *UserRepository_FindByID_Call) RunAndReturn(run func(context.Context, u
 	return _c
 }
 
+// GetUsersByRoles provides a mock function with given fields: ctx, roles
+func (_m *UserRepository) GetUsersByRoles(ctx context.Context, roles model.Roles) ([]model.User, error) {
+	ret := _m.Called(ctx, roles)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUsersByRoles")
+	}
+
+	var r0 []model.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.Roles) ([]model.User, error)); ok {
+		return rf(ctx, roles)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, model.Roles) []model.User); ok {
+		r0 = rf(ctx, roles)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, model.Roles) error); ok {
+		r1 = rf(ctx, roles)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UserRepository_GetUsersByRoles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUsersByRoles'
+type UserRepository_GetUsersByRoles_Call struct {
+	*mock.Call
+}
+
+// GetUsersByRoles is a helper method to define mock.On call
+//   - ctx context.Context
+//   - roles model.Roles
+func (_e *UserRepository_Expecter) GetUsersByRoles(ctx interface{}, roles interface{}) *UserRepository_GetUsersByRoles_Call {
+	return &UserRepository_GetUsersByRoles_Call{Call: _e.mock.On("GetUsersByRoles", ctx, roles)}
+}
+
+func (_c *UserRepository_GetUsersByRoles_Call) Run(run func(ctx context.Context, roles model.Roles)) *UserRepository_GetUsersByRoles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(model.Roles))
+	})
+	return _c
+}
+
+func (_c *UserRepository_GetUsersByRoles_Call) Return(_a0 []model.User, _a1 error) *UserRepository_GetUsersByRoles_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *UserRepository_GetUsersByRoles_Call) RunAndReturn(run func(context.Context, model.Roles) ([]model.User, error)) *UserRepository_GetUsersByRoles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsAdminAccountExists provides a mock function with given fields: ctx
 func (_m *UserRepository) IsAdminAccountExists(ctx context.Context) (bool, error) {
 	ret := _m.Called(ctx)

--- a/mocks/internal_/usecase/UsersUsecaseIface.go
+++ b/mocks/internal_/usecase/UsersUsecaseIface.go
@@ -80,6 +80,64 @@ func (_c *UsersUsecaseIface_GetMyProfile_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// GetTherapistData provides a mock function with given fields: ctx
+func (_m *UsersUsecaseIface) GetTherapistData(ctx context.Context) ([]usecase.GetTherapistDataOutput, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTherapistData")
+	}
+
+	var r0 []usecase.GetTherapistDataOutput
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]usecase.GetTherapistDataOutput, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []usecase.GetTherapistDataOutput); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]usecase.GetTherapistDataOutput)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UsersUsecaseIface_GetTherapistData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTherapistData'
+type UsersUsecaseIface_GetTherapistData_Call struct {
+	*mock.Call
+}
+
+// GetTherapistData is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *UsersUsecaseIface_Expecter) GetTherapistData(ctx interface{}) *UsersUsecaseIface_GetTherapistData_Call {
+	return &UsersUsecaseIface_GetTherapistData_Call{Call: _e.mock.On("GetTherapistData", ctx)}
+}
+
+func (_c *UsersUsecaseIface_GetTherapistData_Call) Run(run func(ctx context.Context)) *UsersUsecaseIface_GetTherapistData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *UsersUsecaseIface_GetTherapistData_Call) Return(_a0 []usecase.GetTherapistDataOutput, _a1 error) *UsersUsecaseIface_GetTherapistData_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *UsersUsecaseIface_GetTherapistData_Call) RunAndReturn(run func(context.Context) ([]usecase.GetTherapistDataOutput, error)) *UsersUsecaseIface_GetTherapistData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewUsersUsecaseIface creates a new instance of UsersUsecaseIface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewUsersUsecaseIface(t interface {


### PR DESCRIPTION
this feature will allow any registered users to get the therapists data.

this feature wasn't related to any user's stories ticket

proof of work:
<img width="1429" height="816" alt="image" src="https://github.com/user-attachments/assets/0dd942c4-6dcc-465c-bba1-bb54216a0ae2" />
<img width="523" height="846" alt="image" src="https://github.com/user-attachments/assets/715ba993-6f0f-4eea-9ca3-8083b92be558" />


unit testing:
<pre>make unit-tests
Running unit tests on: github.com/luckyAkbar/atec github.com/luckyAkbar/atec/internal/common github.com/luckyAkbar/atec/internal/config github.com/luckyAkbar/atec/internal/console github.com/luckyAkbar/atec/internal/db github.com/luckyAkbar/atec/internal/delivery/rest github.com/luckyAkbar/atec/internal/model github.com/luckyAkbar/atec/internal/repository github.com/luckyAkbar/atec/internal/usecase
go test -race -cover -coverprofile=coverage.out -count=1 github.com/luckyAkbar/atec github.com/luckyAkbar/atec/internal/common github.com/luckyAkbar/atec/internal/config github.com/luckyAkbar/atec/internal/console github.com/luckyAkbar/atec/internal/db github.com/luckyAkbar/atec/internal/delivery/rest github.com/luckyAkbar/atec/internal/model github.com/luckyAkbar/atec/internal/repository github.com/luckyAkbar/atec/internal/usecase
        github.com/luckyAkbar/atec              coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/common              coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/config              coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/console             coverage: 0.0% of statements
        github.com/luckyAkbar/atec/internal/db          coverage: 0.0% of statements
ok      github.com/luckyAkbar/atec/internal/delivery/rest       1.105s  coverage: 96.9% of statements
ok      github.com/luckyAkbar/atec/internal/model       1.066s  coverage: 98.2% of statements
ok      github.com/luckyAkbar/atec/internal/repository  1.165s  coverage: 79.8% of statements
ok      github.com/luckyAkbar/atec/internal/usecase     1.662s  coverage: 95.4% of statements</pre>